### PR TITLE
Update supported video formats

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/lib/kodi.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/kodi.py
@@ -78,7 +78,7 @@ def kodi_version():
 def supported_video_extensions():
     supported_video_extensions = xbmc.getSupportedMedia('video').split('|')
     unsupported = ['.url', '.zip', '.rar', '.001', '.7z', '.tar.gz', '.tar.bz2',
-                   '.tar.xz', '.tgz', '.tbz2', '.gz', '.bz2', '.xz', '.tar']
+                   '.tar.xz', '.tgz', '.tbz2', '.gz', '.bz2', '.xz', '.tar', '']
     return [i for i in supported_video_extensions if i not in unsupported]
 
 


### PR DESCRIPTION
For some reason unknown to me, Kodi on Android & coreelec (but not on windows!) reports empty string as supported extension on `xbmc.getSupportedMedia('video')`. (edit: maybe trailing `'|'` or `'||'`?)
This resulted on unrelated files selection when choosing multiple files with realdebrid plugin under these platforms, and returned list had mismatched filename/link dicts.
Adding exclusion of empty string as supported video format cures this.