### PR TITLE
Link tester fixes

### DIFF
--- a/plugin.video.smr_link_tester/default.py
+++ b/plugin.video.smr_link_tester/default.py
@@ -194,7 +194,7 @@ def edit_link(index, path):
 def play_link(link):
     logger.log('Playing Link: |%s|' % (link), log_utils.LOGDEBUG)
     if link.endswith('$$all'):
-        hmf = resolveurl.HostedMediaFile(url=link, return_all=True)
+        hmf = resolveurl.HostedMediaFile(url=link[:-5], return_all=True)
     else:
         hmf = resolveurl.HostedMediaFile(url=link)
     if not hmf:
@@ -225,7 +225,6 @@ def play_link(link):
         except:
             msg = link
         kodi.notify('Resolve Failed: %s' % (msg), duration=7500)
-        print(msg)
         return False
 
     logger.log('Link Resolved: |%s|%s|' % (link, stream_url), log_utils.LOGDEBUG)

--- a/plugin.video.smr_link_tester/default.py
+++ b/plugin.video.smr_link_tester/default.py
@@ -208,6 +208,8 @@ def play_link(link):
             allfiles = hmf.resolve()
             names = [x.get('name') for x in allfiles]
             item = xbmcgui.Dialog().select('Select file to play', names, preselect=0)
+            if item == -1:
+                return False
             stream_url = allfiles[item].get('link')
             if resolveurl.HostedMediaFile(stream_url):
                 stream_url = resolveurl.resolve(stream_url)


### PR DESCRIPTION
1. When I test a magnet link with r-d in the form of `magnet:?xt=urn:btih:{hash}` and append `$$all` at the end, resolving fails with 503 HTTP Error.
I figured the reason is this: `magnet:?xt=urn:btih:{hash}` or `magnet:?xt=urn:btih:{hash}&dn={whatever}` are valid magnet uris. Appending `$$all` in the 2nd form doesn't make it non-valid, but on the 1st form it does. So, strip `$$all` when we resolve.

2. Handle canceling of select dialog, otherwise if cancelled it returns `-1` and starts playing the last file on the list.