### PR TITLE
fix: remove numpy import

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/lib/websocket/_abnf.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/websocket/_abnf.py
@@ -32,13 +32,7 @@ from ._exceptions import *
 from ._utils import validate_utf8
 from threading import Lock
 
-try:
-    if six.PY3:
-        import numpy
-    else:
-        numpy = None
-except ImportError:
-    numpy = None
+numpy = None
 
 try:
     # If wsaccel is available we use compiled routines to mask data.


### PR DESCRIPTION
This fixes a Kodi crash with 5.1.67 for me, but unsure if it causes other issues.

```
2022-05-08 15:09:40.707 T:16007   ERROR <general>: /home/pikdum/.kodi/addons/script.module.resolveurl/lib/resolveurl/lib/websocket/_abnf.py:37: UserWarning: NumPy was imported from a Python sub-interpreter but NumPy does not properly support sub-interpreters. This will likely work for most users but might cause hard to track down issues or subtle bugs. A common user of the rare sub-interpreter feature is wsgi which also allows single-interpreter mode.
                                                   Improvements in the case of bugs are welcome, but is not on the NumPy roadmap, and full support may require significant effort to achieve.
                                                     import numpy
```

Looking through the code, it seems like numpy might just be an optimization?

Might fix #91, if that issue is the same.