### PR TITLE
Fix Motherless

### DIFF
--- a/script.module.resolveurl.xxx/resources/plugins/motherless.py
+++ b/script.module.resolveurl.xxx/resources/plugins/motherless.py
@@ -16,6 +16,7 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+from resolveurl.lib import helpers
 from resolveurl.plugins.__resolve_generic__ import ResolveGeneric
 
 
@@ -23,6 +24,13 @@ class MotherlessResolver(ResolveGeneric):
     name = 'motherless'
     domains = ['motherless.com']
     pattern = r'(?://|\.)(motherless\.com)/(.+)'
+
+    def get_media_url(self, host, media_id):
+        return helpers.get_media_url(
+            self.get_url(host, media_id),
+            patterns=[r'''source\s*src=['"](?P<url>[^'"]+)'''],
+            generic_patterns=False
+        )
 
     def get_url(self, host, media_id):
         return self._default_get_url(host, media_id, template='https://{host}/{media_id}')


### PR DESCRIPTION
We need to set the rest of generic_patterns to false, probably due to a recent small html change as its not pulling the correct file anymore even though its a generic pattern. 