### PR TITLE
Handle ssl errors in generic resolvers

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/lib/helpers.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/helpers.py
@@ -183,7 +183,7 @@ def scrape_sources(html, result_blacklist=None, scheme='http', patterns=None, ge
     return source_list
 
 
-def get_media_url(url, result_blacklist=None, patterns=None, generic_patterns=True, referer=True, redirect=True):
+def get_media_url(url, result_blacklist=None, patterns=None, generic_patterns=True, referer=True, redirect=True, verify=True):
     if patterns is None:
         patterns = []
     scheme = urllib_parse.urlparse(url).scheme
@@ -209,6 +209,8 @@ def get_media_url(url, result_blacklist=None, patterns=None, generic_patterns=Tr
     html = response.content
     if not referer:
         headers.update({'Referer': rurl})
+    if not verify:
+        headers.update({'verifypeer': 'false'})
     headers.update({'Origin': rurl[:-1]})
     source_list = scrape_sources(html, result_blacklist, scheme, patterns, generic_patterns)
     source = pick_source(source_list)

--- a/script.module.resolveurl/lib/resolveurl/lib/helpers.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/helpers.py
@@ -183,7 +183,7 @@ def scrape_sources(html, result_blacklist=None, scheme='http', patterns=None, ge
     return source_list
 
 
-def get_media_url(url, result_blacklist=None, patterns=None, generic_patterns=True, referer=True, redirect=True, verify=True):
+def get_media_url(url, result_blacklist=None, patterns=None, generic_patterns=True, referer=True, redirect=True, verifypeer=True):
     if patterns is None:
         patterns = []
     scheme = urllib_parse.urlparse(url).scheme
@@ -209,7 +209,7 @@ def get_media_url(url, result_blacklist=None, patterns=None, generic_patterns=Tr
     html = response.content
     if not referer:
         headers.update({'Referer': rurl})
-    if not verify:
+    if not verifypeer:
         headers.update({'verifypeer': 'false'})
     headers.update({'Origin': rurl[:-1]})
     source_list = scrape_sources(html, result_blacklist, scheme, patterns, generic_patterns)


### PR DESCRIPTION
Least for the returned source url as i run into this more often than the whole site.

Besides building out the resolver, i can do something like the following:


```python
def get_media_url(self, host, media_id):
    return helpers.get_media_url(
        self.get_url(host, media_id)
    ) + '&verifypeer=false'
```

But its not really the cleanest in my opinion vs using verify=False.
What do you think?