### PR TITLE
Archiveorg pattern adjustment

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/archiveorg.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/archiveorg.py
@@ -23,7 +23,7 @@ from resolveurl.lib import helpers
 class ArchiveResolver(ResolveGeneric):
     name = 'Archive'
     domains = ['archive.org']
-    pattern = r'(?://|\.)(archive\.org)/embed/([0-9a-zA-Z-_]+)'
+    pattern = r'(?://|\.)(archive\.org)/embed/([0-9a-zA-Z-_\.]+)'
 
     def get_media_url(self, host, media_id):
         return helpers.get_media_url(


### PR DESCRIPTION
@Gujal00 What do you think about building this out and pulling from another location in the html?

Would be nice to watch some of the classics i already scrape in higher quality when available.
An example would be:
`hxxps://archive.org/embed/All.Quiet.on.the.Western.Front.1930_201605`

![archpic](https://user-images.githubusercontent.com/50564043/215369089-700c99ab-a7bf-453f-802c-f7883b420ff7.PNG)
