### PR TITLE
Add "email" string to avoid warning in logs. Closes: #490.

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/lib/strings.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/strings.py
@@ -87,6 +87,7 @@ STRINGS = {
     'hours': 33067,
     'ub_auth_reset': 33068,
     'ub_authorized': 33069,
+    'email': 33070,
     'clean_settings': 33101,
     'settings_cleaned': 33102
 }

--- a/script.module.resolveurl/resources/language/resource.language.cs_cz/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.cs_cz/strings.po
@@ -292,6 +292,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox Resolver autorizován"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Vyčistit soubor nastavení"

--- a/script.module.resolveurl/resources/language/resource.language.de_de/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.de_de/strings.po
@@ -292,6 +292,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox Resolver autorisiert"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Einstellungsdatei bereinigen"

--- a/script.module.resolveurl/resources/language/resource.language.el_gr/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.el_gr/strings.po
@@ -293,6 +293,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Ο επιλυτής Uptobox έχει εγκριθεί"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Καθαρίστε το αρχείο ρυθμίσεων"

--- a/script.module.resolveurl/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.en_gb/strings.po
@@ -293,6 +293,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr ""
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr ""

--- a/script.module.resolveurl/resources/language/resource.language.en_us/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.en_us/strings.po
@@ -296,6 +296,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox Resolver Authorized"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr ""

--- a/script.module.resolveurl/resources/language/resource.language.es_es/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.es_es/strings.po
@@ -292,6 +292,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox Resolver Autorizado"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Limpiar archivo de configuración"

--- a/script.module.resolveurl/resources/language/resource.language.gl_es/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.gl_es/strings.po
@@ -292,6 +292,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Procesador Ubtobox Autorizado"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Limpar o ficheiro de configuración"

--- a/script.module.resolveurl/resources/language/resource.language.hr_hr/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.hr_hr/strings.po
@@ -298,6 +298,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox razrješitelj ovjeren"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Očistite datoteku postavki"

--- a/script.module.resolveurl/resources/language/resource.language.hu_hu/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.hu_hu/strings.po
@@ -284,6 +284,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox Resolver autorizáció sikeres"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Tisztítsa meg a beállítási fájlt"

--- a/script.module.resolveurl/resources/language/resource.language.it_it/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.it_it/strings.po
@@ -295,6 +295,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Resolver Uptobox Autorizzato"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Pulisci il file delle impostazioni"

--- a/script.module.resolveurl/resources/language/resource.language.iw_il/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.iw_il/strings.po
@@ -295,6 +295,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox מורשה פותר"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "נקה את קובץ ההגדרות"

--- a/script.module.resolveurl/resources/language/resource.language.nl_nl/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.nl_nl/strings.po
@@ -297,6 +297,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox Resolver Geauthoriseerd"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Instellingenbestand opschonen"

--- a/script.module.resolveurl/resources/language/resource.language.no_no/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.no_no/strings.po
@@ -295,6 +295,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox-resolver autorisert"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Rengjør innstillingsfil"

--- a/script.module.resolveurl/resources/language/resource.language.ro_ro/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.ro_ro/strings.po
@@ -294,6 +294,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Rezolver Uptobox autorizat"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Curățați fișierul de setări"

--- a/script.module.resolveurl/resources/language/resource.language.sk_sk/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.sk_sk/strings.po
@@ -293,6 +293,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox resolver autorizovaný"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Vyčistiť súbor nastavení"

--- a/script.module.resolveurl/resources/language/resource.language.sv_se/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.sv_se/strings.po
@@ -292,6 +292,10 @@ msgctxt "#33069"
 msgid "Uptobox Resolver Authorised"
 msgstr "Uptobox Resolver auktorisering"
 
+msgctxt "#33070"
+msgid "email"
+msgstr "email"
+
 msgctxt "#33101"
 msgid "Clean Settings File"
 msgstr "Rensa inställningsfil"


### PR DESCRIPTION
I just add `email` string and 1:1 translations.