### PR TITLE
Fix typo in waaw domain

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/waaw.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/waaw.py
@@ -30,7 +30,9 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class WaawResolver(ResolveUrl):
     name = 'Waaw'
-    domains = ['waaw.ac', 'netu.ac', 'hqq.ac', 'waaw.tv', 'netu.tv', 'hqq.to',
+    domains = ['waaw.ac', 'netu.ac', 'hqq.ac',
+               'waaw.tv', 'netu.tv', 'hqq.tv',
+               'waav.to', 'netu.to', 'hqq.to',
                'doplay.store', 'younetu.com', 'stbnetu.xyz']
     pattern = r'(?://|\.)((?:you|stb)?(?:waaw|netu|hqq|doplay)\.(?:ac|tv|to|store|com|xyz))/' \
               r'(?:watch_video\.php\?v=|.+?\?vid=|e/|f/)([a-zA-Z0-9]+)'

--- a/script.module.resolveurl/lib/resolveurl/plugins/waaw.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/waaw.py
@@ -32,7 +32,7 @@ class WaawResolver(ResolveUrl):
     name = 'Waaw'
     domains = ['waaw.ac', 'netu.ac', 'hqq.ac',
                'waaw.tv', 'netu.tv', 'hqq.tv',
-               'waav.to', 'netu.to', 'hqq.to',
+               'waaw.to', 'netu.to', 'hqq.to',
                'doplay.store', 'younetu.com', 'stbnetu.xyz']
     pattern = r'(?://|\.)((?:you|stb)?(?:waaw|netu|hqq|doplay)\.(?:ac|tv|to|store|com|xyz))/' \
               r'(?:watch_video\.php\?v=|.+?\?vid=|e/|f/)([a-zA-Z0-9]+)'


### PR DESCRIPTION
https://github.com/Gujal00/ResolveURL/commit/1b14ac586fcbdffe29ba568feb27d9f4eaaa5d02 had a typo. It should be `waaw.to` and not `waav.to`.