### PR TITLE
Fixed vidmoly resolver

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/vidmoly.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vidmoly.py
@@ -16,23 +16,38 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from resolveurl.plugins.__resolve_generic__ import ResolveGeneric
+from resolveurl.resolver import ResolveUrl, ResolverError
+from resolveurl import common
 from resolveurl.lib import helpers
 
 
-class VidMolyResolver(ResolveGeneric):
+class VidMolyResolver(ResolveUrl):
     name = 'VidMoly'
     domains = ['vidmoly.me', 'vidmoly.to', 'vidmoly.net']
     pattern = r'(?://|\.)(vidmoly\.(?:me|to|net))/(?:embed-|w/)?([0-9a-zA-Z]+)'
 
     def get_media_url(self, host, media_id, subs=False):
-        return helpers.get_media_url(
-            self.get_url(host, media_id),
-            patterns=[r'''sources:\s*\[{file:"(?P<url>[^"]+)'''],
+        web_url = self.get_url(host, media_id)
+        headers = {"User-Agent": common.FF_USER_AGENT, "Referer": web_url, "Sec-Fetch-Dest": "iframe"}
+        html = self.net.http_GET(web_url, headers=headers).content
+        sources = helpers.scrape_sources(
+            html,
             result_blacklist=['.mpd'],
-            referer=True,
-            subs=subs
+            patterns=[r'''sources:\s*\[{file:"(?P<url>[^"]+)'''],
+            generic_patterns=False
         )
+
+        if subs:
+            subtitles = helpers.scrape_subtitles(html, web_url)
+        
+        if sources:
+            stream_url = helpers.pick_source(sources) + helpers.append_headers(headers)
+            if subs:
+                return stream_url, subtitles
+            return stream_url
+        
+        raise ResolverError('No video found')
+            
 
     def get_url(self, host, media_id):
         return self._default_get_url(host, media_id, template='https://vidmoly.net/embed-{media_id}.html')


### PR DESCRIPTION
Hello there,

I noticed that this link won't get resolved by the old resolver: `https://vidmoly.to/embed-mxhsgqjpk9lq.html`

If I requested the URL from a browser session where the video wasn't embedded, it didn't play either. So then I figured that it needs the `Sec-Fetch-Dest: iframe` header, otherwise the site just renders `Please wait`...

Unfortunately this means that we need to ditch the current impl. that uses the generic resolver.

The fix seems to work fine on my end. I have tested another vidmoly link that I had (see #698) and it was ok too.