### PR TITLE
Explicit content pattern for vidstore

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/vidstore.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vidstore.py
@@ -28,6 +28,8 @@ class VidStoreResolver(ResolveGeneric):
     def get_media_url(self, host, media_id, subs=False):
         return helpers.get_media_url(
             self.get_url(host, media_id),
+            patterns=[r'''<source\s*src=['"](?P<url>[^'"]+)['"]\s*type=['"]video/mp4['"]'''],
+            generic_patterns=False,
             referer=True,
             subs=subs,
         )


### PR DESCRIPTION
Unfortunately after my previous fix, I encountered a case when the generic pattern would pick up the subtitle as video source, which obviously won't work. So we must specify the media pattern. This way subtitles won't be considered as the media itself in some rare cases.

Looks like the generic subtitle extractor can stay for now.

I can provide links if necessary in DM/email as the links expire pretty quick.