### PR TITLE
Fixed filemoon

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/filemoon.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/filemoon.py
@@ -30,7 +30,7 @@ class FileMoonResolver(ResolveUrl):
                'filemoon.wf', 'cinegrab.com', 'filemoon.eu', 'filemoon.art', 'moonmov.pro',
                'kerapoxy.cc', 'furher.in', '1azayf9w.xyz']
     pattern = r'(?://|\.)((?:filemoon|cinegrab|moonmov|kerapoxy|furher|1azayf9w)\.(?:sx|to|in|link|nl|wf|com|eu|art|pro|cc|xyz))' \
-              r'/(?:e|d|download)/([0-9a-zA-Z$:/.]+)'
+              r'/(?:e|d|download)/([0-9a-zA-Z$:/._-]+)'
 
     def get_media_url(self, host, media_id):
         if '$$' in media_id:
@@ -39,12 +39,19 @@ class FileMoonResolver(ResolveUrl):
         else:
             referer = False
 
+        if '/' in media_id:
+            media_id = media_id.split('/')[0]
+
         web_url = self.get_url(host, media_id)
         headers = {'User-Agent': common.RAND_UA}
         if referer:
             headers.update({'Referer': referer})
 
         html = self.net.http_GET(web_url, headers=headers).content
+        if '<h1>Page not found</h1>' in html:
+            web_url = web_url.replace('/e/', '/d/')
+            html = self.net.http_GET(web_url, headers=headers).content
+
         html += helpers.get_packed_data(html)
         r = re.search(r'var\s*postData\s*=\s*(\{.+?\})', html, re.DOTALL)
         if r:
@@ -79,4 +86,4 @@ class FileMoonResolver(ResolveUrl):
         raise ResolverError('Video not found')
 
     def get_url(self, host, media_id):
-        return self._default_get_url(host, media_id, template='https://{host}/d/{media_id}')
+        return self._default_get_url(host, media_id, template='https://{host}/e/{media_id}')

--- a/script.module.resolveurl/lib/resolveurl/plugins/filemoon.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/filemoon.py
@@ -64,17 +64,19 @@ class FileMoonResolver(ResolveUrl):
             surl = helpers.tear_decode(edata.get('file'), edata.get('seed'))
             if surl:
                 headers.pop('X-Requested-With')
+                headers["verifypeer"] = "false"
                 return surl + helpers.append_headers(headers)
         else:
             r = re.search(r'sources:\s*\[{\s*file:\s*"([^"]+)', html, re.DOTALL)
             if r:
                 headers.update({
                     'Referer': web_url,
-                    'Origin': urllib_parse.urljoin(web_url, '/')[:-1]
+                    'Origin': urllib_parse.urljoin(web_url, '/')[:-1],
+                    "verifypeer": "false"
                 })
                 return r.group(1) + helpers.append_headers(headers)
 
         raise ResolverError('Video not found')
 
     def get_url(self, host, media_id):
-        return self._default_get_url(host, media_id, template='https://{host}/e/{media_id}')
+        return self._default_get_url(host, media_id, template='https://{host}/d/{media_id}')


### PR DESCRIPTION
Some links didn't play for me, for example: `https://filemoon.sx/d/qd3fo7w2b7xs/The.Walk.2015.2160p.4K.WEB.x265.10bit.AAC5.1-.mp4` when using the `/e/` media path, but they work fine using `/d/`. Cert also seems to be invalid on my linux host so I added verifypeer=false:

```
2024-07-08 15:13:57.535 T:303172   error <general>: CCurlFile::Stat - <https://redacted.cdn112.com/hls2/01/05914/redacted/master.m3u8?t=redacted&s=1720444436&e=43200&f=29570531&srv=29&asn=8412&sp=4000|User-Agent=Mozilla%2F5.0+%28Windows+NT+10.0%3B+Win64%3B+x64%29+AppleWebKit%2F537.36+%28KHTML%2C+like+Gecko%29+Chrome%2F117.0.8464.47+Safari%2F537.36+OPR%2F117.0.8464.47&Referer=https%3A%2F%2Ffilemoon.sx%2Fd%2Fujsbmdc4domu%2FDune2.2024.mp4&Origin=https%3A%2F%2Ffilemoon.sx&verifypeer=false> Failed: SSL peer certificate or SSH remote key was not OK(60)
```