### PR TITLE
New resolver: dzen

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/dzen.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/dzen.py
@@ -1,0 +1,46 @@
+"""
+    Plugin for ResolveUrl
+    Copyright (C) 2024 MrDini123 (github.com/movieshark)
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from resolveurl.lib import helpers
+from resolveurl import common
+from resolveurl.resolver import ResolveUrl, ResolverError
+
+
+class DzenResolver(ResolveUrl):
+    name = 'dzen'
+    domains = ['dzen.ru']
+    pattern = r'(?://|\.)(dzen\.ru)/((?:video/watch|embed)/[0-9a-zA-Z]+)'
+
+    def get_media_url(self, host, media_id):
+        web_url = self.get_url(host, media_id)
+        headers = {'User-Agent': common.RAND_UA,
+                   'Cookie': 'zen_sso_checked=1; zen_vk_sso_checked=1'}
+        html = self.net.http_GET(web_url, headers=headers).content
+        sources = helpers.scrape_sources(
+            html,
+            patterns=[r"(?P<url>https://[^\"']+\.m3u8)"],
+            generic_patterns=False
+        )
+        if sources:
+            headers.pop('Cookie')
+            return helpers.pick_source(sources) + helpers.append_headers(headers)
+        raise ResolverError('No video found')
+
+
+    def get_url(self, host, media_id):
+        return self._default_get_url(host, media_id, template='https://{host}/{media_id}')


### PR DESCRIPTION
Only encountered one source that uses it: `https://dzen.ru/embed/vtLFUSjhyUBk`. In its direct link form: `https://dzen.ru/video/watch/654f376f8d22c3188bbd0e16`.

The latter prompts for a login/redirect, that's why the weird hack to set those two cookies. Seemingly once those are set, we get the direct links. Embeds don't have this issue.

URL extraction could be improved, but I found it too complex to extract and parse the JSON object.

HLS links don't really play for me with Kodi's built-in player, I assume it times out. It takes a really long time for `ffplay` on my linux box to start the playback when I am using HLS, because it seemingly downloads all manifests and probes their qualities first. I assume this is where Kodi gives up, because it takes really long. ISA plays it fine though. Which is why I think its a good addition (I mean it resolves and that's what ResolveURL really is for).

MPD is also available and preferred by the web player too. Has less quality levels to, so it plays quicker for me. I wonder why is it [blacklisted by ResolveURL](https://github.com/Gujal00/ResolveURL/blob/b006d9487d743eea144da1c25b82bab8139ed26b/script.module.resolveurl/lib/resolveurl/lib/helpers.py#L163). If I pass the MPD url back to SMR tester, it plays just fine (assuming using Kodi's built-in player).