### PR TITLE
Fixed vk resolver

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/vk.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vk.py
@@ -66,7 +66,8 @@ class VKResolver(ResolveUrl):
             if 'doc/' in media_id or media_id.startswith('doc'):
                 source = jd.get('docUrl')
             else:
-                source = jd.get('params')[0].get('hls')
+                params = jd.get('params')[0]
+                source = params.get('hls') or params.get('hls_ondemand')
             if source:
                 return source + helpers.append_headers(headers)
 


### PR DESCRIPTION
Hi,

This didn't work for me: `https://vk.com/video_ext.php?oid=866933920&id=456239406&hash=4a7ef88111ce9d6d`. There is no `hls` key in the response, just `hls_ondemand`. That one seems to work fine.