### PR TITLE
Don't use embeds for voe

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
@@ -115,4 +115,4 @@ class VoeResolver(ResolveUrl):
         raise ResolverError('No video found')
 
     def get_url(self, host, media_id):
-        return self._default_get_url(host, media_id, template='https://{host}/e/{media_id}')
+        return self._default_get_url(host, media_id, template='https://{host}/{media_id}')


### PR DESCRIPTION
Hi,

I got this error in the logs:

```
ResolveURL: HTTPError Error - From: Voe Link: https://voe.sx/okgfu3mude7m: HTTP Error 404: Not Found
```

So I checked the resolver. Seemingly it used `/e/` for embeds. I simply got rid of it and now all my links play again. Not sure if there are links that only play with `/e/`, but I couldn't find any. I have tested many links now, all seem to work fine.