### PR TITLE
Fixed GDrive embed playback

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/googlevideo.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/googlevideo.py
@@ -143,7 +143,7 @@ class GoogleResolver(ResolveUrl):
         elif 'drive.google' in link or 'docs.google' in link:
             link = re.findall('/file/.*?/([^/]+)', link)[0]
             link = 'https://drive.google.com/get_video_info?docid=' + link
-            response = self.net.http_GET(link)
+            response = self.net.http_GET(link, headers=self.headers)
             sources = self._parse_gdocs(response.content)
         elif 'youtube.googleapis.com' in link:
             cid = re.search(r'cid=([\w]+)', link)


### PR DESCRIPTION
Hi,

I was annoyed that the playback of GDrive links are broken with a 403 now so I took a deeper look and they indeed started complicating their streaming. While I successfully implemented that too, its far more difficult. So while accidentally playing around with the API I found a little workaround. Seemingly if you set a matching user-agent, you are able to get the links working using the old method again. :)

I am sending a link for testing in DM.