### PR TITLE
[debrid resolvers] do not raise error upon user transfer cancelation

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/alldebrid.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/alldebrid.py
@@ -185,7 +185,8 @@ class AllDebridResolver(ResolveUrl):
                             )
                             if not keep_transfer:
                                 self.__delete_transfer(transfer_id)
-                            raise ResolverError('{0} ID {1} :: {2}'.format(i18n('transfer'), transfer_id, i18n('user_cancelled')))
+                            logger.log_debug('ResolveURL AllDebrid {0} ID {1} :: {2}'.format(i18n('transfer'), transfer_id, i18n('user_cancelled')))
+                            return
                         elif 5 <= transfer_info.get('statusCode') <= 10:
                             self.__delete_transfer(transfer_id)
                             raise ResolverError('{0} ID {1} :: {2}'.format(i18n('transfer'), transfer_id, transfer_info.get('status')))

--- a/script.module.resolveurl/lib/resolveurl/plugins/debrid_link.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/debrid_link.py
@@ -168,7 +168,8 @@ class DebridLinkResolver(ResolveUrl):
                             )
                             if not keep_transfer:
                                 self.__delete_transfer(transfer_id)
-                            raise ResolverError('Transfer ID {0} :: {1}'.format(transfer_id, i18n('user_cancelled')))
+                            logger.log_debug('ResolveURL Debrid-Link Transfer ID {0} :: {1}'.format(transfer_id, i18n('user_cancelled')))
+                            return
             return
 
         except Exception as e:

--- a/script.module.resolveurl/lib/resolveurl/plugins/realdebrid.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/realdebrid.py
@@ -85,7 +85,8 @@ class RealDebridResolver(ResolveUrl):
                                     )
                                     if not keep_transfer:
                                         self.__delete_torrent(torrent_id)
-                                    raise ResolverError('Real-Debrid: Torrent ID  {0} :: {1}'.format(torrent_id, i18n('user_cancelled')))
+                                    logger.log_debug('Real-Debrid: Torrent ID {0} :: {1}'.format(torrent_id, i18n('user_cancelled')))
+                                    return
                                 elif any(x in status for x in STALLED):
                                     self.__delete_torrent(torrent_id)
                                     raise ResolverError('Real-Debrid: Torrent ID %s has stalled | REASON: %s' % (torrent_id, status))
@@ -153,7 +154,8 @@ class RealDebridResolver(ResolveUrl):
                                             )
                                             if not keep_transfer:
                                                 self.__delete_torrent(torrent_id)
-                                            raise ResolverError('Real-Debrid: Torrent ID {0} :: {1}'.format(torrent_id, i18n('user_cancelled')))
+                                            logger.log_debug('Real-Debrid: Torrent ID {0} :: {1}'.format(torrent_id, i18n('user_cancelled')))
+                                            return
                                         elif any(x in status for x in STALLED):
                                             self.__delete_torrent(torrent_id)
                                             raise ResolverError('Real-Debrid: Torrent ID %s has stalled | REASON: %s' % (torrent_id, status))


### PR DESCRIPTION
Exception deletes transfer, canceling user's choice to keep the transfer active