### PR TITLE
Rely on embeds within BigWarp resolver

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/bigwarp.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/bigwarp.py
@@ -23,14 +23,15 @@ from resolveurl.lib import helpers
 class BigWarpResolver(ResolveGeneric):
     name = 'BigWarp'
     domains = ['bigwarp.io']
-    pattern = r'(?://|\.)(bigwarp\.io)/(?:e/)?([0-9a-zA-Z=]+)'
+    pattern = r'(?://|\.)(bigwarp\.io)/(?:e/|embed-)?([0-9a-zA-Z=]+)(?:\.html)?'
 
     def get_media_url(self, host, media_id, subs=False):
         return helpers.get_media_url(
             self.get_url(host, media_id),
             patterns=[r'''file\s*:\s*['"](?P<url>[^'"]+)['"],\s*label\s*:\s*['"](?P<label>\d+p?)'''],
-            subs=subs
+            subs=subs,
+            referer=False
         )
 
     def get_url(self, host, media_id):
-        return self._default_get_url(host, media_id, template='https://{host}/{media_id}')
+        return self._default_get_url(host, media_id, template='https://{host}/embed-{media_id}.html')

--- a/script.module.resolveurl/lib/resolveurl/plugins/bigwarp.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/bigwarp.py
@@ -23,7 +23,7 @@ from resolveurl.lib import helpers
 class BigWarpResolver(ResolveGeneric):
     name = 'BigWarp'
     domains = ['bigwarp.io']
-    pattern = r'(?://|\.)(bigwarp\.io)/(?:e/|embed-)?([0-9a-zA-Z=]+)(?:\.html)?'
+    pattern = r'(?://|\.)(bigwarp\.io)/(?:e/|embed-)?([0-9a-zA-Z=]+)'
 
     def get_media_url(self, host, media_id, subs=False):
         return helpers.get_media_url(


### PR DESCRIPTION
Hi,

I noticed that some links wouldn't play with the current resolver version, because they are restricted to embed only playback, such as this link: `https://bigwarp.io/embed-0k3eajkmnkhb.html`

Therefore I went ahead and changed the code to always use embeds. I am not sure if there are some links that forbid embeds and work on the site, but it seems to be common in ResolveURL resolvers to prefer embeds anyway and I tried many different links, all worked within embeds.

`referer=False` is really important otherwise I get `Video embed restricted for this domain`. I assume proper referer support might needs to be added in the future (if one reports broken links).