### PR TITLE
fix(torbox): handle when file_id is 0 properly

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/torbox.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/torbox.py
@@ -210,7 +210,7 @@ class TorBoxResolver(ResolveUrl):
         if len(files) > 1 and file_id is None:
             _file = max(files, key=lambda x: x.get("size"))
             file_id = _file.get("id")
-        elif file_id:
+        elif isinstance(file_id, int):
             pass
         else:
             file_id = files[0]["id"]


### PR DESCRIPTION
Without this, it instead falls back to the else and incorrectly grabs the first file instead of the one with id 0.
I've been running into this with batches - it'll improperly start episode 1 instead of episode 10 or similar.
