### PR TITLE
Replace &amp; (html encoded &) with simple & in media_id

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/vk.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vk.py
@@ -36,6 +36,7 @@ class VKResolver(ResolveUrl):
                    'Origin': ref[:-1]}
 
         video_list = ''
+        media_id = media_id.replace('&amp;', '&')
         try:
             query = urllib_parse.parse_qs(media_id)
             oid, video_id = query['oid'][0], query['id'][0]


### PR DESCRIPTION
On some pages, e.g. `https://onlinefilmvilag2.eu/cikkek/2k---4k-filmek/vissza-a-jovobe-3--back-to-the-future-part-iii---4k-.html` in the vkvideo.ru url the & sign in url parameters are url encoded (at the linked video: `https://vkvideo.ru/video_ext.php?oid=-230067415&amp;id=456239076&amp;hd=2&amp;hash=e357333ff33b44ab`. The browser render the html decoded version. I don't know, that this can happen on other sites too. If no, maybe this should be solved at addon level, but with this solution I resolved the issue at resolveURL.