### PR TITLE
filemoon.py; add c1z39 and remove commas from r.group1

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/filemoon.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/filemoon.py
@@ -30,9 +30,9 @@ class FileMoonResolver(ResolveUrl):
                'filemoon.wf', 'cinegrab.com', 'filemoon.eu', 'filemoon.art', 'moonmov.pro',
                'kerapoxy.cc', 'furher.in', '1azayf9w.xyz', '81u6xl9d.xyz', 'smdfs40r.skin',
                'bf0skv.org', 'z1ekv717.fun', 'l1afav.net', '222i8x.lol', '8mhlloqo.fun', '96ar.com',
-               'xcoic.com', 'f51rm.com']
+               'xcoic.com', 'f51rm.com', 'c1z39.com']
     pattern = r'(?://|\.)((?:filemoon|cinegrab|moonmov|kerapoxy|furher|1azayf9w|81u6xl9d|' \
-              r'smdfs40r|bf0skv|z1ekv717|l1afav|222i8x|8mhlloqo|96ar|xcoic|f51rm)' \
+              r'smdfs40r|bf0skv|z1ekv717|l1afav|222i8x|8mhlloqo|96ar|xcoic|f51rm|c1z39)' \
               r'\.(?:sx|to|s?k?in|link|nl|wf|com|eu|art|pro|cc|xyz|org|fun|net|lol))' \
               r'/(?:e|d|download)/([0-9a-zA-Z$:/._-]+)'
 
@@ -93,7 +93,13 @@ class FileMoonResolver(ResolveUrl):
                     'Origin': urllib_parse.urljoin(web_url, '/')[:-1],
                     "verifypeer": "false"
                 })
-                return r.group(1) + helpers.append_headers(headers)
+                group1 = r.group(1)
+                if "/," in group1:
+                    parsed_url = urllib_parse.urlparse(r.group(1))
+                    gurl = (re.split(r',', parsed_url.path)[0] +
+                            re.split(r',', parsed_url.path)[1] + '/' + re.split(r'/', parsed_url.path)[-1])
+                    group1 = urllib_parse.urlunparse(parsed_url._replace(path=gurl))
+                return group1 + helpers.append_headers(headers)
 
         raise ResolverError('Video not found')
 


### PR DESCRIPTION
```
https://c1z39.com/e/2xqwfh71shrc
https://c1z39.com/e/i2qj36jy9yyq
https://c1z39.com/d/psxqc00r873s
https://filemoon.sx/e/vtcioxw7ubds
```

updated lines 96 to 102 to remove commas and extras from r.group1.  

I was getting something like: `/hls2/10/08537/,zjyc1kg4turr_h,lang/eng/zjyc1kg4turr_eng,.urlset/master.m3u8`
and should be: `/hls2/10/08537/zjyc1kg4turr_h/master.m3u8`

Feel free to edit, or give me some tips on how to make it cleaner.