### PR TITLE
Create dramacoolmen.py

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/dramacoolmen.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/dramacoolmen.py
@@ -1,0 +1,39 @@
+"""
+    Plugin for ResolveURL
+    Copyright (C) 2025 dramafool
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from resolveurl.lib import helpers
+from resolveurl import common
+from resolveurl.resolver import ResolveUrl, ResolverError
+
+
+class DramaCoolResolver(ResolveUrl):
+    name = 'DramaCool'
+    domains = ['dramacool.men']
+    pattern = r'(?://|\.)(dramacool\.men)/(?:embed/)?([0-9a-zA-Z]+)'
+
+    def get_media_url(self, host, media_id):
+        return helpers.get_media_url(
+            self.get_url(host, media_id),
+            patterns=[
+                r'''links=\{"\w+":"(?P<url>[^\"]+)'''
+            ],
+            generic_patterns=False,
+        )
+
+    def get_url(self, host, media_id):
+        return 'https://{0}/embed/{1}'.format(host, media_id)

--- a/script.module.resolveurl/lib/resolveurl/plugins/dramacoolmen.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/dramacoolmen.py
@@ -19,7 +19,7 @@
 from resolveurl.lib import helpers
 from resolveurl.plugins.__resolve_generic__ import ResolveGeneric
 
-class DramaCoolResolver(ResolveGeneric):
+class DramaCoolMenResolver(ResolveGeneric):
     name = 'DramaCoolMen'
     domains = ['dramacool.men']
     pattern = r'(?://|\.)(dramacool\.men)/(?:embed/)?([0-9a-zA-Z]+)'

--- a/script.module.resolveurl/lib/resolveurl/plugins/dramacoolmen.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/dramacoolmen.py
@@ -17,12 +17,10 @@
 """
 
 from resolveurl.lib import helpers
-from resolveurl import common
-from resolveurl.resolver import ResolveUrl, ResolverError
+from resolveurl.plugins.__resolve_generic__ import ResolveGeneric
 
-
-class DramaCoolResolver(ResolveUrl):
-    name = 'DramaCool'
+class DramaCoolResolver(ResolveGeneric):
+    name = 'DramaCoolMen'
     domains = ['dramacool.men']
     pattern = r'(?://|\.)(dramacool\.men)/(?:embed/)?([0-9a-zA-Z]+)'
 


### PR DESCRIPTION
dramacool is a website so plugin is named dramacoolmen to differentiate between the website and domain.

Supported Domains: dramacool.men

`https://dramacool.men/embed/tx7fm8o9u3rj`
`https://dramacool.men/embed/k4j08aowimo9`