### PR TITLE
send.cm and sendit.cloud issues

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/send.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/send.py
@@ -34,7 +34,7 @@ class SendResolver(ResolveUrl):
         html = self.net.http_GET(web_url, headers=headers).content
         if "The file you were looking for doesn't exist." not in html:
             data = helpers.get_hidden(html)
-            burl = 'https://{}'.format(host)
+            burl = 'https://send.now'
             url = helpers.get_redirect_url(burl, headers=headers, form_data=data)
             if url != burl:
                 headers.update({'Referer': web_url})


### PR DESCRIPTION
`https://send.now/54sackeeedd3`|send.now works
`https://send.cm/54sackeeedd3`|send.cm was failing
`https://sendit.cloud/54sackeeedd3`|sendit.cloud was failing

```
https://send.now/7gs894e283b1
https://send.cm/7gs894e283b1
https://sendit.cloud/7gs894e283b1
```