### PR TITLE
byse additional domain

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/byse.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/byse.py
@@ -29,7 +29,7 @@ class ByseResolver(ResolveUrl):
     domains = [
         'f16px.com', 'bysesayeveum.com', 'bysetayico.com', 'bysevepoin.com', 'bysezejataos.com',
         'bysekoze.com', 'bysesukior.com', 'bysejikuar.com', 'bysefujedu.com', 'bysedikamoum.com',
-        'bysebuho.com', 'filemoon.sx', 'filemoon.to', 'filemoon.in', 'filemoon.link', 'filemoon.nl',
+        'bysebuho.com', "byse.sx", 'filemoon.sx', 'filemoon.to', 'filemoon.in', 'filemoon.link', 'filemoon.nl',
         'filemoon.wf', 'cinegrab.com', 'filemoon.eu', 'filemoon.art', 'moonmov.pro', '96ar.com',
         'kerapoxy.cc', 'furher.in', '1azayf9w.xyz', '81u6xl9d.xyz', 'smdfs40r.skin', 'c1z39.com',
         'bf0skv.org', 'z1ekv717.fun', 'l1afav.net', '222i8x.lol', '8mhlloqo.fun', 'f51rm.com',
@@ -37,7 +37,7 @@ class ByseResolver(ResolveUrl):
     ]
     pattern = r'(?://|\.)((?:filemoon|cinegrab|moonmov|kerapoxy|furher|1azayf9w|81u6xl9d|f16px|' \
               r'smdfs40r|bf0skv|z1ekv717|l1afav|222i8x|8mhlloqo|96ar|xcoic|f51rm|c1z39|boosteradx|' \
-              r'byse(?:sayeveum|tayico|vepoin|zejataos|koze|sukior|jikuar|fujedu|dikamoum|buho|wihe))' \
+              r'byse(?:sayeveum|tayico|vepoin|zejataos|koze|sukior|jikuar|fujedu|dikamoum|buho|wihe)?)' \
               r'\.(?:sx|to|s?k?in|link|nl|wf|com|eu|art|pro|cc|xyz|org|fun|net|lol|online))' \
               r'/(?:e|d|download)/([0-9a-zA-Z]+)'
 
@@ -74,7 +74,7 @@ class ByseResolver(ResolveUrl):
         raise ResolverError('Video Link Not Found')
 
     def get_url(self, host, media_id):
-        redirect_domains = ['boosteradx.online']
+        redirect_domains = ['boosteradx.online', "byse.sx"]
         if host in redirect_domains:
             host = 'streamlyplayer.online'
         return self._default_get_url(host, media_id, 'https://{host}/api/videos/{media_id}/embed/playback')


### PR DESCRIPTION
This PR fixes an issue where the Zoom file uploader, when uploading a file to Byse, returns https://byse.sx/d/... URLs that result in “Access blocked on this domain” instead of an accessible file link.