### PR TITLE
sl cookie with value "deleted" should not be used

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/videa.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/videa.py
@@ -94,7 +94,7 @@ class VideaResolver(ResolveUrl):
             player_page = response.content
             cookie = response.get_headers(as_dict=True).get('Set-Cookie', '')
         match = re.search(r'\bsl=([^;]+)', cookie)
-        if match:
+        if match and match.group(1) != "deleted":
             self.cookie = match.group(0)
         nonce = re.search(r'_xt\s*=\s*"([^"]+)"', player_page).group(1)
         lo = nonce[:32]


### PR DESCRIPTION
For some movies the sl cookie has a value "deleted". Opening video with this cookie results HTTP 403. Withouth the cookie it works fine.
Example URL: https://videa.hu/player?v=2yiOujf19EPzQI7i&autoplay=1&enableJsApi=1&apiKey=PKeut6dEjAJYKYRp