### PR TITLE
filelions, byse, voe and veev domain additions

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/byse.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/byse.py
@@ -34,12 +34,13 @@ class ByseResolver(ResolveUrl):
         'kerapoxy.cc', 'furher.in', '1azayf9w.xyz', '81u6xl9d.xyz', 'smdfs40r.skin', 'c1z39.com',
         'bf0skv.org', 'z1ekv717.fun', 'l1afav.net', '222i8x.lol', '8mhlloqo.fun', 'f51rm.com',
         'xcoic.com', 'filemoon.nl', 'boosteradx.online', 'streamlyplayer.online', 'bysewihe.com',
-        'byselapuix.com', 'embedplaybyse.top', 'sb1254w9megshle.org', 'streamlyplayero.online'
+        'byselapuix.com', 'embedplaybyse.top', 'sb1254w9megshle.org', 'streamlyplayero.online',
+        'moflix-stream.link'
     ]
     pattern = (
         r'(?://|\.)((?:filemoon|cinegrab|moonmov|kerapoxy|furher|1azayf9w|81u6xl9d|f16px|sb1254w9megshle|'
-        r'smdfs40r|bf0skv|z1ekv717|l1afav|222i8x|8mhlloqo|96ar|xcoic|f51rm|c1z39|boosteradx|vepoin|streamlyplayero?|'
-        r'(?:embedplay)?byse(?:sayeveum|tayico|zejataos|koze|sukior|jikuar|fujedu|dikamoum|buho|wihe|lapuix)?)'
+        r'smdfs40r|bf0skv|z1ekv717|l1afav|222i8x|8mhlloqo|96ar|xcoic|f51rm|c1z39|boosteradx|streamlyplayero?|moflix-stream|'
+        r'(?:embedplay)?byse(?:sayeveum|tayico|zejataos|koze|sukior|jikuar|fujedu|dikamoum|buho|wihe|lapuix|vepoin)?)'
         r'\.(?:sx|top?|s?k?in|link|nl|wf|com|eu|art|pro|cc|xyz|org|fun|net|lol|online))'
         r'/(?:(?:e|d|download)/)?([0-9a-zA-Z]+)'
     )

--- a/script.module.resolveurl/lib/resolveurl/plugins/filelions.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/filelions.py
@@ -37,14 +37,14 @@ class FileLionsResolver(ResolveUrl):
         'streamvid.su', 'movearnpre.com', 'bingezove.com', 'dingtezuni.com', 'dinisglows.com',
         'ryderjet.com', 'e4xb5c2xnz.sbs', 'smoothpre.com', 'videoland.sbs', 'taylorplayer.com',
         'mivalyo.com', 'vidhidefast.com', 'peytonepre.com', 'dintezuvio.com', 'callistanise.com',
-        'minochinos.com', 'earnvids.xyz', 'lookmovie2.skin', 'morencius.com'
+        'minochinos.com', 'earnvids.xyz', 'lookmovie2.skin', 'morencius.com', 'kinoger.be'
     ]
     pattern = r'(?://|\.)((?:filelions|ajmidyadfihayh|alhayabambi|techradar|moflix-stream|azipcdn|' \
               r'[mad]lions|lumiawatch|javplaya|javlion|fviplions|egsyxutd|fdewsdc|vidhide|peytone|' \
               r'anime7u|coolciima|gsfomqu|katomen|dht|6sfkrspw4u|ryderjet|e4xb5c2xnz|smooth|morencius|' \
               r'streamvid|movearnpre|bingezove|dingtezuni|dinisglows|motvy55|videoland|mivalyo|lookmovie2|' \
-              r'taylorplayer|dintezuvio|callistanise|minochinos|earnvids)(?:pro|vip|pre|plus|hub|fast)?' \
-              r'\.(?:su|com?|to|sbs|ink|click|pro|live|store|xyz|top|online|site|fun|skin))' \
+              r'taylorplayer|dintezuvio|callistanise|minochinos|earnvids|kinoger)(?:pro|vip|pre|plus|hub|fast)?' \
+              r'\.(?:su|com?|to|sbs|ink|click|pro|live|store|xyz|top|online|site|fun|skin|be))' \
               r'/((?:s|v|f|d|e|embed|file|download)/[0-9a-zA-Z$:/.]+)'
 
     def get_media_url(self, host, media_id, subs=False):

--- a/script.module.resolveurl/lib/resolveurl/plugins/veev.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/veev.py
@@ -27,8 +27,8 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class VeevResolver(ResolveUrl):
     name = 'Veev'
-    domains = ['veev.to', 'poophq.com', 'doods.to']
-    pattern = r'(?://|\.)((?:veev|poophq|doods)\.(?:to|com))/(?:e|d)/([0-9a-zA-Z]+)'
+    domains = ['veev.to', 'veev.pro', 'poophq.com', 'doods.to']
+    pattern = r'(?://|\.)((?:veev|poophq|doods)\.(?:to|com|pro))/(?:e|d)/([0-9a-zA-Z]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)

--- a/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
@@ -27,7 +27,7 @@ class VoeResolver(ResolveUrl):
     name = 'Voe'
     domains = [
         'voe.sx', 'voe-unblock.com', 'voe-unblock.net', 'voeunblock.com', 'un-block-voe.net',
-        'voeunbl0ck.com', 'voeunblck.com', 'voeunblk.com', 'voe-un-block.com', 'jonathansociallike.com'
+        'voeunbl0ck.com', 'voeunblck.com', 'voeunblk.com', 'voe-un-block.com', 'jonathansociallike.com',
         'voeun-block.net', 'v-o-e-unblock.com', 'edwardarriveoften.com', 'nathanfromsubject.com',
         'audaciousdefaulthouse.com', 'launchreliantcleaverriver.com', 'kennethofficialitem.com',
         'reputationsheriffkennethsand.com', 'fittingcentermondaysunday.com', 'lukecomparetwo.com',
@@ -56,7 +56,8 @@ class VoeResolver(ResolveUrl):
         'lukesitturn.com', 'mikaylaarealike.com', 'christopheruntilpoint.com', 'walterprettytheir.com',
         'crystaltreatmenteast.com', 'lauradaydo.com', 'smoki.cc', 'lancewhosedifficult.com',
         'ogladaj.me', 'dianaavoidthey.com', 'jefferycontrolmodel.com', 'marissasharecareer.com',
-        'charlestoughrace.com', 'ianrequireadult.com', 'timmaybealready.com', 'jessicayeahcatch.com'
+        'charlestoughrace.com', 'ianrequireadult.com', 'timmaybealready.com', 'jessicayeahcatch.com',
+        'kinoger.ru'
     ]
     domains += ['voeunblock{}.com'.format(x) for x in range(1, 11)]
     pattern = (
@@ -83,8 +84,8 @@ class VoeResolver(ResolveUrl):
         r'jonathansociallike|mariatheserepublican|johnalwayssame|jilliandescribecompany|'
         r'lukesitturn|mikaylaarealike|christopheruntilpoint|walterprettytheir|crystaltreatmenteast|'
         r'lauradaydo|smoki|lancewhosedifficult|ogladaj|dianaavoidthey|jefferycontrolmodel|marissasharecareer|'
-        r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|'
-        r'(?:v-?o-?e)?(?:-?un-?bl[o0]?c?k\d{0,2})?(?:-?voe)?)\.(?:sx|com|net|cc|me))/'
+        r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|'
+        r'(?:v-?o-?e)?(?:-?un-?bl[o0]?c?k\d{0,2})?(?:-?voe)?)\.(?:sx|com|net|cc|me|ru))/'
         r'(?:e/)?([0-9A-Za-z]+)'
     )
 


### PR DESCRIPTION
Splitting the rest of #1451 into a PR as requested — sorry for the whole-file dump there.

Four files, domains and pattern only, no code touched:

- filelions: kinoger.be. The other half is already in, thanks for 3df1980 — but right now no plugin
  claims the domain at all, so this closes the gap. Its embed page is EarnVids, already here as
  earnvids.xyz, and it serves the var links = {...} form this plugin already parses. The caller
  supplies the referer through the $$ convention, the embed is domain-locked otherwise.
- byse: moflix-stream.link, a Byse frontend that the existing code resolves unchanged. Also a
  pattern fix while in there — bysevepoin.com is in domains but cannot match, because the byse
  suffix group does not list vepoin and the standalone vepoin entry only covers vepoin.com, which
  is NXDOMAIN while bysevepoin.com resolves. Moving vepoin into the suffix group fixes the real
  domain and drops the dead one.
- voe: kinoger.ru, which 302s to the current VOE mirror and runs through the existing code path
  unchanged, loader path included. Adding the kinoger domain rather than the mirror since VOE
  rotates those. Also a missing comma that glued jonathansociallike.com and voeun-block.net into
  one entry.
- veev: veev.pro, a mirror of veev.to landing on the same CDN file.

All confirmed playing on Kodi. Test details are in #1451.