### PR TITLE
playmate resolver added

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/playmate.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/playmate.py
@@ -1,0 +1,52 @@
+"""
+    Plugin for ResolveURL
+    Copyright (C) 2026 gujal
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import json
+from six.moves import urllib_parse
+from resolveurl import common
+from resolveurl.lib import helpers
+from resolveurl.resolver import ResolveUrl, ResolverError
+
+
+class PlaymateResolver(ResolveUrl):
+    name = 'Playmate'
+    domains = ['playmate.to']
+    pattern = r'(?://|\.)(playmate\.to)/(?:watch|embed|e|v)/([0-9a-zA-Z]+)'
+
+    def get_media_url(self, host, media_id, subs=False):
+        web_url = self.get_url(host, media_id)
+        headers = {'User-Agent': common.RAND_UA,
+                   'Referer': urllib_parse.urljoin(web_url, '/')}
+        pdata = {'c': media_id,
+                 'd': 'web'}
+        html = self.net.http_POST(web_url, form_data=pdata, headers=headers, jdata=True).content
+        r = json.loads(html)
+        if r.get('sx'):
+            url = r.get('sx') + helpers.append_headers(headers)
+            if subs:
+                subtitles = {}
+                s = r.get('kx')
+                if s:
+                    subtitles = {x.get('sl'): x.get('sf') for x in s}
+                return url, subtitles
+            return url
+
+        raise ResolverError('Unable to locate stream URL.')
+
+    def get_url(self, host, media_id):
+        return self._default_get_url(host, media_id, template='https://{host}/api/s')


### PR DESCRIPTION
Adds a resolver for playmate.to, which is not covered by any existing plugin.

The /watch/<code> page is only an SPA shell; the player runs in an iframe on
/embed/<code>. The embed page loads an obfuscated player-core.min.js, but the
stream itself needs no deobfuscation at runtime:

  POST https://playmate.to/api/s
  body: {"c": "<filecode>", "d": "web"}

The JSON response uses short keys: sx = stream URL, kx = subtitle list
(sl = language, sf = file path), tx/ix/lx/ax/cx = metadata. sx is a plain HLS
master playlist, no encryption involved - the site's crypto-js/pako usage is
only for its telemetry beacon on /api/v.

Notes:
- The API returns 403 without a User-Agent header. Referer and Origin are not
  checked. The stream host itself accepts requests without any headers, but the
  request headers are appended to the returned URL to stay consistent with the
  other resolvers.
- Segments are served as .css/.js with matching fake MIME types but are valid
  MPEG-TS (verified: 670/670 and 810/810 sync bytes on the 188-byte grid).
- /e/ and /v/ currently 404 on the site, but are listed as valid link formats
  in its own takedown form, so they are included in the pattern - only the
  filecode is taken from the URL.
- Playmate offers custom domains to uploaders, so user-mapped domains will not
  match this pattern.

Tested against master (28fdaa6) on Kodi 21.3 (64-bit) / Android 16:
valid_url, both /watch/ and /embed/ forms, subtitle mapping, and
HostedMediaFile.resolve() all resolve to a playable master playlist.
Confirmed playing in Kodi.

Sample link:
https://playmate.to/watch/xu0vZ0NnFnRDu