### PR TITLE
new resolver playmate.to / firestream fix / voe new domain

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/firestream.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/firestream.py
@@ -26,7 +26,7 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 class FireStreamResolver(ResolveUrl):
     name = 'FireStream'
     domains = ['firestream.to']
-    pattern = r'(?://|\.)(firestream\.to)/(?:e|v)/([0-9a-zA-Z_]+)'
+    pattern = r'(?://|\.)(firestream\.to)/(?:e|v)/([0-9a-zA-Z_-]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)

--- a/script.module.resolveurl/lib/resolveurl/plugins/playmate.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/playmate.py
@@ -1,0 +1,52 @@
+"""
+    Plugin for ResolveURL
+    Copyright (C) 2026 gujal
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import json
+from six.moves import urllib_parse
+from resolveurl import common
+from resolveurl.lib import helpers
+from resolveurl.resolver import ResolveUrl, ResolverError
+
+
+class PlaymateResolver(ResolveUrl):
+    name = 'Playmate'
+    domains = ['playmate.to']
+    pattern = r'(?://|\.)(playmate\.to)/(?:watch|embed|e|v)/([0-9a-zA-Z]+)'
+
+    def get_media_url(self, host, media_id, subs=False):
+        web_url = self.get_url(host, media_id)
+        headers = {'User-Agent': common.RAND_UA,
+                   'Referer': urllib_parse.urljoin(web_url, '/')}
+        pdata = {'c': media_id,
+                 'd': 'web'}
+        html = self.net.http_POST(web_url, form_data=pdata, headers=headers, jdata=True).content
+        r = json.loads(html)
+        if r.get('sx'):
+            url = r.get('sx') + helpers.append_headers(headers)
+            if subs:
+                subtitles = {}
+                s = r.get('kx')
+                if s:
+                    subtitles = {x.get('sl'): x.get('sf') for x in s}
+                return url, subtitles
+            return url
+
+        raise ResolverError('Unable to locate stream URL.')
+
+    def get_url(self, host, media_id):
+        return self._default_get_url(host, media_id, template='https://{host}/api/s')

--- a/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
@@ -57,7 +57,7 @@ class VoeResolver(ResolveUrl):
         'crystaltreatmenteast.com', 'lauradaydo.com', 'smoki.cc', 'lancewhosedifficult.com',
         'ogladaj.me', 'dianaavoidthey.com', 'jefferycontrolmodel.com', 'marissasharecareer.com',
         'charlestoughrace.com', 'ianrequireadult.com', 'timmaybealready.com', 'jessicayeahcatch.com',
-        'kinoger.ru'
+        'kinoger.ru', 'johnbeyondnation.com'
     ]
     domains += ['voeunblock{}.com'.format(x) for x in range(1, 11)]
     pattern = (
@@ -84,7 +84,7 @@ class VoeResolver(ResolveUrl):
         r'jonathansociallike|mariatheserepublican|johnalwayssame|jilliandescribecompany|'
         r'lukesitturn|mikaylaarealike|christopheruntilpoint|walterprettytheir|crystaltreatmenteast|'
         r'lauradaydo|smoki|lancewhosedifficult|ogladaj|dianaavoidthey|jefferycontrolmodel|marissasharecareer|'
-        r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|'
+        r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|johnbeyondnation|'
         r'(?:v-?o-?e)?(?:-?un-?bl[o0]?c?k\d{0,2})?(?:-?voe)?)\.(?:sx|com|net|cc|me|ru))/'
         r'(?:e/)?([0-9A-Za-z]+)'
     )


### PR DESCRIPTION
This PR contains three changes: a new resolver for playmate.to, a pattern fix for firestream and an additional domain for voe.

**playmate.py — new resolver (playmate.to)**
Example link: https://playmate.to/watch/xu0vZ0NnFnRDu
The player POSTs the filecode to `https://{host}/api/s` and receives JSON containing a plain HLS streaming URL plus optional subtitles. The API requires a User-Agent header (403 without one); UA and Referer are appended to the returned URL. The pattern also covers the /embed/, /e/ and /v/ link forms the site itself lists as valid. Verified end to end: resolves to the HLS playlist, segments confirmed as valid MPEG-TS. 
Note: the site offers a custom-domain feature for uploaders.

**firestream.py — media_id pattern fix**
firestream media ids can contain hyphens, e.g. https://firestream.to/e/e-5DNrdv. The current character class `[0-9a-zA-Z_]` silently truncates the id at the hyphen (the pattern still matches but only captures `e`), so the resolve API call fails. Added `-` to the character class. Verified against the live link above: resolves to the HLS playlist, segments confirmed as valid MPEG-TS. Existing ids without hyphens are unaffected.

**voesx.py — additional domain**
Adds johnbeyondnation.com to domains and pattern. It is a current VOE redirect target: kinoger.ru and chuckle-tube.com (both already listed) 302-redirect to `https://johnbeyondnation.com/e/<id>`, and the server sets a `voe_session` cookie. Links pointing directly at this domain currently don't match.