### PR TITLE
new resolver playmate.to / firestream fix / streamix + voe additional domains

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/firestream.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/firestream.py
@@ -26,7 +26,7 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 class FireStreamResolver(ResolveUrl):
     name = 'FireStream'
     domains = ['firestream.to']
-    pattern = r'(?://|\.)(firestream\.to)/(?:e|v)/([0-9a-zA-Z_]+)'
+    pattern = r'(?://|\.)(firestream\.to)/(?:e|v)/([0-9a-zA-Z_-]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)

--- a/script.module.resolveurl/lib/resolveurl/plugins/playmate.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/playmate.py
@@ -1,0 +1,52 @@
+"""
+    Plugin for ResolveURL
+    Copyright (C) 2026 gujal
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+import json
+from six.moves import urllib_parse
+from resolveurl import common
+from resolveurl.lib import helpers
+from resolveurl.resolver import ResolveUrl, ResolverError
+
+
+class PlaymateResolver(ResolveUrl):
+    name = 'Playmate'
+    domains = ['playmate.to']
+    pattern = r'(?://|\.)(playmate\.to)/(?:watch|embed|e|v)/([0-9a-zA-Z]+)'
+
+    def get_media_url(self, host, media_id, subs=False):
+        web_url = self.get_url(host, media_id)
+        headers = {'User-Agent': common.RAND_UA,
+                   'Referer': urllib_parse.urljoin(web_url, '/')}
+        pdata = {'c': media_id,
+                 'd': 'web'}
+        html = self.net.http_POST(web_url, form_data=pdata, headers=headers, jdata=True).content
+        r = json.loads(html)
+        if r.get('sx'):
+            url = r.get('sx') + helpers.append_headers(headers)
+            if subs:
+                subtitles = {}
+                s = r.get('kx')
+                if s:
+                    subtitles = {x.get('sl'): x.get('sf') for x in s}
+                return url, subtitles
+            return url
+
+        raise ResolverError('Unable to locate stream URL.')
+
+    def get_url(self, host, media_id):
+        return self._default_get_url(host, media_id, template='https://{host}/api/s')

--- a/script.module.resolveurl/lib/resolveurl/plugins/streamix.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/streamix.py
@@ -27,10 +27,10 @@ class StreamixResolver(ResolveUrl):
     name = 'Streamix'
     domains = [
         'streamix.so', 'stmix.io', 'vidara.so', 'vidara.to', 'vidaraa.cc', 'vidmatrixa.com',
-        'kinoger.pw'
+        'kinoger.pw', 'viewdara.com', 'thebesthosterv.com'
     ]
     pattern = (
-        r'(?://|\.)((?:st(?:rea)?mix|vid(?:ar|matrix)a*|kinoger)'
+        r'(?://|\.)((?:st(?:rea)?mix|vid(?:ar|matrix)a*|viewdara|thebesthosterv|kinoger)'
         r'\.(?:so|io|to|cc|com|pw))/(?:e|v)/([0-9a-zA-Z]+)'
     )
 

--- a/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
@@ -57,7 +57,7 @@ class VoeResolver(ResolveUrl):
         'crystaltreatmenteast.com', 'lauradaydo.com', 'smoki.cc', 'lancewhosedifficult.com',
         'ogladaj.me', 'dianaavoidthey.com', 'jefferycontrolmodel.com', 'marissasharecareer.com',
         'charlestoughrace.com', 'ianrequireadult.com', 'timmaybealready.com', 'jessicayeahcatch.com',
-        'kinoger.ru'
+        'kinoger.ru', 'johnbeyondnation.com'
     ]
     domains += ['voeunblock{}.com'.format(x) for x in range(1, 11)]
     pattern = (
@@ -84,7 +84,7 @@ class VoeResolver(ResolveUrl):
         r'jonathansociallike|mariatheserepublican|johnalwayssame|jilliandescribecompany|'
         r'lukesitturn|mikaylaarealike|christopheruntilpoint|walterprettytheir|crystaltreatmenteast|'
         r'lauradaydo|smoki|lancewhosedifficult|ogladaj|dianaavoidthey|jefferycontrolmodel|marissasharecareer|'
-        r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|'
+        r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|johnbeyondnation|'
         r'(?:v-?o-?e)?(?:-?un-?bl[o0]?c?k\d{0,2})?(?:-?voe)?)\.(?:sx|com|net|cc|me|ru))/'
         r'(?:e/)?([0-9A-Za-z]+)'
     )

--- a/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
@@ -57,7 +57,10 @@ class VoeResolver(ResolveUrl):
         'crystaltreatmenteast.com', 'lauradaydo.com', 'smoki.cc', 'lancewhosedifficult.com',
         'ogladaj.me', 'dianaavoidthey.com', 'jefferycontrolmodel.com', 'marissasharecareer.com',
         'charlestoughrace.com', 'ianrequireadult.com', 'timmaybealready.com', 'jessicayeahcatch.com',
-        'kinoger.ru', 'johnbeyondnation.com'
+        'kinoger.ru', 'johnbeyondnation.com', 'jeanprofessorcentral.com', 'juliewomanwish.com',
+        'garylargeavailable.com', 'jennifereconomicgive.com', 'pamelachangemission.com',
+        'ellenpoliticalfollow.com', 'caseyimpactstation.com', 'matthewhotelscience.com',
+        'jessicachoosemake.com', 'stevenfamilyedge.com'
     ]
     domains += ['voeunblock{}.com'.format(x) for x in range(1, 11)]
     pattern = (
@@ -85,6 +88,9 @@ class VoeResolver(ResolveUrl):
         r'lukesitturn|mikaylaarealike|christopheruntilpoint|walterprettytheir|crystaltreatmenteast|'
         r'lauradaydo|smoki|lancewhosedifficult|ogladaj|dianaavoidthey|jefferycontrolmodel|marissasharecareer|'
         r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|johnbeyondnation|'
+        r'jeanprofessorcentral|juliewomanwish|garylargeavailable|jennifereconomicgive|'
+        r'pamelachangemission|ellenpoliticalfollow|caseyimpactstation|matthewhotelscience|'
+        r'jessicachoosemake|stevenfamilyedge|'
         r'(?:v-?o-?e)?(?:-?un-?bl[o0]?c?k\d{0,2})?(?:-?voe)?)\.(?:sx|com|net|cc|me|ru))/'
         r'(?:e/)?([0-9A-Za-z]+)'
     )


### PR DESCRIPTION
This PR contains four changes: a new resolver for playmate.to, a pattern fix for firestream, and additional domains for streamix and voe.

playmate.py — new resolver (playmate.to)
Example link: https://playmate.to/watch/xu0vZ0NnFnRDu
The player POSTs the filecode to https://{host}/api/s and receives JSON containing a plain HLS streaming URL plus optional subtitles. The API requires a User-Agent header (403 without one); UA and Referer are appended to the returned URL. The pattern also covers the /embed/, /e/ and /v/ link forms the site itself lists as valid. Verified end to end: resolves to the HLS playlist, segments confirmed as valid MPEG-TS.
Note: the site offers a custom-domain feature for uploaders.

text for the prevoius pr for the new resolver 

Adds a resolver for playmate.to, which is not covered by any existing plugin.

The /watch/ page is only an SPA shell; the player runs in an iframe on
/embed/. The embed page loads an obfuscated player-core.min.js, but the
stream itself needs no deobfuscation at runtime:

POST https://playmate.to/api/s
body: {"c": "", "d": "web"}

The JSON response uses short keys: sx = stream URL, kx = subtitle list
(sl = language, sf = file path), tx/ix/lx/ax/cx = metadata. sx is a plain HLS
master playlist, no encryption involved - the site's crypto-js/pako usage is
only for its telemetry beacon on /api/v.

Notes:


    The API returns 403 without a User-Agent header. Referer and Origin are not
    checked. The stream host itself accepts requests without any headers, but the
    request headers are appended to the returned URL to stay consistent with the
    other resolvers.

    Segments are served as .css/.js with matching fake MIME types but are valid
    MPEG-TS (verified: 670/670 and 810/810 sync bytes on the 188-byte grid).

    /e/ and /v/ currently 404 on the site, but are listed as valid link formats
    in its own takedown form, so they are included in the pattern - only the
    filecode is taken from the URL.

Tested against master (28fdaa6) on Kodi 21.3 (64-bit) / Android 16:
valid_url, both /watch/ and /embed/ forms, subtitle mapping, and
HostedMediaFile.resolve() all resolve to a playable master playlist.
Confirmed playing in Kodi.

-------------------------------

firestream.py — media_id pattern fix
firestream media ids can contain hyphens, e.g. https://firestream.to/e/e-5DNrdv. The current character class [0-9a-zA-Z_] silently truncates the id at the hyphen (the pattern still matches but only captures e), so the resolve API call fails. Added - to the character class. Verified against the live link above: resolves to the HLS playlist, segments confirmed as valid MPEG-TS. Existing ids without hyphens are unaffected.

-------------------------------

streamix.py — additional domains
Adds viewdara.com and thebesthosterv.com. Both are mirrors of the platform already covered by this resolver: the same filecode returns the identical streaming URL through viewdara, thebesthosterv, kinoger.pw and vidara.to. Only domains and the name alternation are extended — the existing /api/stream POST with device: web works unchanged, no get_url special-casing needed. Verified end to end against a live filecode on both new domains: resolves to the HLS playlist, segments confirmed as valid MPEG-TS. Existing domains unaffected.

-------------------------------

voesx.py — additional domains (redirect targets)
Adds johnbeyondnation.com plus ten further VOE rotation domains. johnbeyondnation.com is a current redirect target: kinoger.ru and chuckle-tube.com (both already listed) 302-redirect to https://johnbeyondnation.com/e/<id>, and the server sets a voe_session cookie. The other ten were found by following the redirect chain from the already-listed jessicayeahcatch.com, which 302-hops deterministically through jeanprofessorcentral.com → juliewomanwish.com → garylargeavailable.com → jennifereconomicgive.com → pamelachangemission.com → ellenpoliticalfollow.com → caseyimpactstation.com → matthewhotelscience.com → jessicachoosemake.com → stevenfamilyedge.com (reproduced across three runs). None of these currently match, so links pointing directly at any of them fail. All use the standard /e/<id> form; the resolver code path is identical to the existing VOE domains.