### PR TITLE
fix-kinoger-domains

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/kinoger.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/kinoger.py
@@ -39,9 +39,10 @@ class KinoGerResolver(ResolveUrl):
     pattern = (
         r'(?://|\.)((?:kinoger|wasuytm|ultrastream|(?:shiid4u|player)\.upn|(?:moflix|cimanow|embedplay(?:apiupn)?|'
         r'(?:tuktuk|ultra)\.rpmvid|filedecrypt|(?:dzo|srbe84)\.vidplayer|video(?:shar\.uns|land)|'
-        r'w1tv|(?:flixfilmesonline\.|filma365\.|moviehax\.)?strp2p|flimmer\.rpmvip|(?:t1|kinoger)\.p2pplay|'
-        r'asianembed|securecdn|watch\.(?:ezplayer|streamcasthub)|kinoger\.(?:embed4me|seekplays)|'
-        r'filmi9)\.(?:upns|rpmplay)|disneycdn|vidmoly|animeshqip\.uns)'
+        r'w1tv|(?:flixfilmesonline\.|filma365\.|moviehax\.)?strp2p|flimmer\.rpmvip|'
+        r'asianembed|securecdn|watch\.(?:ezplayer|streamcasthub)|'
+        r'filmi9)\.(?:upns|rpmplay)|(?:t1|kinoger)\.p2pplay|kinoger\.(?:embed4me|seekplays)|'
+        r'disneycdn|vidmoly|animeshqip\.uns)'
         r'\.(?:[mr]e|one|xyz|store|online|c[oa]m|net|l?i(?:nk|ve)|bio|cfd|site|shop|pro|cc|vip))/#([A-Za-z0-9]+)'
     )
 


### PR DESCRIPTION
Three domains listed in domains never match pattern, so valid_url rejects them and the resolver never runs: kinoger.embed4me.vip, kinoger.seekplays.pro and kinoger.p2pplay.pro.

All three sit inside the alternation branch ending in \.(?:upns|rpmplay), which effectively requires kinoger.embed4me.upns.vip. Only moflix, cimanow, embedplay(apiupn) and filmi9 genuinely carry .upns/.rpmplay in their hostnames. Moving the affected entries out of that branch fixes it.

t1.p2pplay.pro is included as well, since it shares the (?:t1|kinoger) group with kinoger.p2pplay.pro and has the same problem — splitting the group would add code for a worse result.

Examples of links that are currently rejected, taken from kinoger.to:
```
https://kinoger.embed4me.vip/#jnhyt
https://kinoger.seekplays.pro/#j9bbl
https://kinoger.embed4me.vip/#g5e1y
```
The last one is embedded on `https://kinoger.to/stream/11266-house-of-the-dragon-stream-deutsch-stream-german-s.html`, in case a containing page is useful.

Verified against current master: with the patch, all three domains pass valid_url and host/media_id are extracted correctly. All 16 hosts currently embedded on kinoger.to were checked before and after — only these were failing, nothing else changed. Negative probes (unrelated domains, the same host without the /#id form, bare p2pplay.pro) are still rejected.

To be clear about scope: these links do not play yet even with this patch. get_media_url reads ddata.get('source') while the API now returns hlsVideoTiktok, and that field is a path that has to be combined with streamingConfig rather than used directly. That is reported separately in #1467 and is not addressed here. This PR only fixes the pattern so the resolver is reachable at all.