### PR TITLE
Update voesx.py

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
@@ -60,7 +60,7 @@ class VoeResolver(ResolveUrl):
         'kinoger.ru', 'johnbeyondnation.com', 'jeanprofessorcentral.com', 'juliewomanwish.com',
         'garylargeavailable.com', 'jennifereconomicgive.com', 'pamelachangemission.com',
         'ellenpoliticalfollow.com', 'caseyimpactstation.com', 'matthewhotelscience.com',
-        'jessicachoosemake.com', 'stevenfamilyedge.com'
+        'jessicachoosemake.com', 'stevenfamilyedge.com', 'tracylocalschool.com'
     ]
     domains += ['voeunblock{}.com'.format(x) for x in range(1, 11)]
     pattern = (
@@ -90,7 +90,7 @@ class VoeResolver(ResolveUrl):
         r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|johnbeyondnation|'
         r'jeanprofessorcentral|juliewomanwish|garylargeavailable|jennifereconomicgive|'
         r'pamelachangemission|ellenpoliticalfollow|caseyimpactstation|matthewhotelscience|'
-        r'jessicachoosemake|stevenfamilyedge|'
+        r'jessicachoosemake|stevenfamilyedge|tracylocalschool|'
         r'(?:v-?o-?e)?(?:-?un-?bl[o0]?c?k\d{0,2})?(?:-?voe)?)\.(?:sx|com|net|cc|me|ru))/'
         r'(?:e/)?([0-9A-Za-z]+)'
     )


### PR DESCRIPTION
VOE has rotated to a new front domain, tracylocalschool.com, which is not
covered yet.

Changes (2 lines):
- tracylocalschool.com appended to the domains list
- tracylocalschool appended to the pattern alternation; the trailing
  \.(?:sx|com|net|cc|me|ru) already covers the TLD

Evidence that this domain is VOE:
- https://tracylocalschool.com/ redirects to https://voe.sx/
- file ids behave identically on tracylocalschool.com and on kinoger.ru
  (already in the domains list): a known id returns the same page byte
  for byte, stale and fabricated ids return the same 404 page byte for
  byte

Source page: https://filmpalast.to/stream/the-walking-dead-daryl-dixon-s03e07
carries the id f7bpdor76fik.

Verified against a patched master: valid_url is True for both the /e/<id>
and the bare /<id> form, get_host_and_id returns host and id, and all
other listed domains still match exactly as before (no regression).
Negative checks (tracylocalschool.de, tracylocalschoolx.com) are
rejected. The example link plays, tested on Kodi 21.3 64bit, Android 16.

Example link: https://tracylocalschool.com/f7bpdor76fik