### PR TITLE
filelions: prefer hls2/hls3 over hls4

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/filelions.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/filelions.py
@@ -64,7 +64,7 @@ class FileLionsResolver(ResolveUrl):
         links = re.search(r'var\s*links\s*=\s*([^;]+)', html)
         if links:
             links = ast.literal_eval(links.group(1))
-            source = links.get('hls4') or links.get('hls3') or links.get('hls2')
+            source = links.get('hls2') or links.get('hls3') or links.get('hls4')
             if source.startswith('/'):
                 source = urllib_parse.urljoin(web_url, source)
             source = source + helpers.append_headers(headers)


### PR DESCRIPTION
<html><body>
<!--StartFragment--><html><head></head><body><p>The <code>hls4</code> variant serves TS segments disguised as PNG images, which Kodi's built-in demuxer cannot play. <code>hls2</code> and <code>hls3</code> serve the same content without the disguise.</p>
<p>Every <code>hls4</code> segment starts with a complete 70-byte 1x1 PNG (IHDR/IDAT/IEND), followed by regular MPEG-TS at offset 70. FFmpeg probes the magic bytes at offset 0, opens a PNG image stream, decodes the single pixel and reports EOF. In Kodi this shows up as:</p>
<pre><code>Creating video codec with codec id: 61
CDVDVideoCodecFFmpeg::Open() Using codec: PNG (Portable Network Graphics) image
Process - eof reading from demuxer
</code></pre>
<p>No error dialog, just a black screen and back to the menu.</p>
<h3>Evidence</h3>
<p>ffprobe on the exact same segment bytes:</p>

input | result
-- | --
hls4 segment as served | format=png_pipe, codec=png, 1x1
same bytes minus the first 70 | format=mpegts, h264 1916x1080 + aac


<p><code>hls2</code> was present on every video tested, so it goes first. <code>hls3</code> is missing on some, so it cannot simply replace <code>hls4</code> as the primary. <code>hls4</code> stays as the last fallback in case a host only offers that one.</p>
<p>Confirmed on Kodi 21.3 (Android): <code>moflix-stream.click</code> sources that previously produced a black screen now play. Note that these hosts are flaky independently of this change — the master playlist occasionally returns 502 and the stream then fails to open; retrying works. Over 30 fresh resolves across 10 videos, 29 returned a playable master.</p>
<p>Worth noting for anyone chasing the same symptom: ffprobe opens the full <code>hls3</code> master playlist including its separate audio renditions without trouble, so the multiple audio tracks these hosts use are not the cause — only the disguised segments are.</p>
<h3>Test links</h3>
<p>Live at the time of writing:</p>
<pre><code>https://moflix-stream.click/embed/koaq1oo3he2g
https://moflix-stream.click/embed/cov799xg6or4
https://kinoger.be/v/lgt63npky2do$$https://kinoger.to/
https://kinoger.be/v/z32rcccdkij8$$https://kinoger.to/
</code></pre>
<p><code>kinoger.be</code> is domain-locked and needs the <code>$$</code> referer as shown.</p>
<p>If you would rather keep the old order reachable, I am happy to add a <code>prefer_hls</code>-style setting like in voe instead.</p></body></html><!--EndFragment-->
</body>
</html>