### PR TITLE
New Resolver Anonstream

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/anonstream.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/anonstream.py
@@ -1,0 +1,40 @@
+"""
+    Plugin for ResolveURL
+    Copyright (C) 2026 TempleLain
+
+    This program is free software: you can redistribute it and/or modify
+    it under the terms of the GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    This program is distributed in the hope that it will be useful,
+    but WITHOUT ANY WARRANTY; without even the implied warranty of
+    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+    GNU General Public License for more details.
+
+    You should have received a copy of the GNU General Public License
+    along with this program.  If not, see <http://www.gnu.org/licenses/>.
+"""
+
+from resolveurl.lib import helpers
+from resolveurl.plugins.__resolve_generic__ import ResolveGeneric
+
+
+class AnonStreamResolver(ResolveGeneric):
+    name = 'AnonStream'
+    domains = ['anonstream.co']
+    pattern = r'(?://|\.)(anonstream\.co)/(?:embed-|e/|d/)?(\w+)'
+
+    def get_media_url(self, host, media_id):
+        # The embed page is domain locked: any Referer other than the embedding
+        # site is answered with "Video embed restricted for this domain".
+        # Sending none at all is accepted, so referer is disabled here.
+        return helpers.get_media_url(
+            self.get_url(host, media_id),
+            patterns=[r'''sources:\s*\[{src:\s*["'](?P<url>[^"']+)'''],
+            generic_patterns=False,
+            referer=False
+        )
+
+    def get_url(self, host, media_id):
+        return self._default_get_url(host, media_id, template='https://{host}/embed-{media_id}.html')


### PR DESCRIPTION
New resolver for anonstream.co. Standard XFileSharing layout — the MP4 is in the page in plain text, so this is a ResolveGeneric with a single pattern, in the same shape as vidello.py.

One thing worth pointing out: the embed page is domain locked. With any Referer other than the embedding site it answers with a 38-byte body reading "Video embed restricted for this domain" instead of the player. I checked this with the site's own host, with an unrelated site and with a made-up domain — all three are refused. Sending no Referer at all is accepted, so the plugin passes referer=False. Hardcoding one embedding site's Referer would tie the plugin to a single source site, which is why it is done this way.

Tested against a live link:

`https://anonstream.co/e/acz73wxmvgzl`
  -> anon200.anonstream.co/v/01/00000/acz73wxmvgzl_o/o.mp4
     206, ftyp
  -> ffprobe: mov/mp4, 7379 s
     h264 1920x816
     aac 6ch [deu]
     aac 6ch [eng]

Also verified playing in Kodi 21.3 on Android.

/e/<id>, /embed-<id>.html and /<id> all map to the same media id. Negative checks (anonstream.com, xanonstream.co, anonstream.co.<other>.com, bare host) are all rejected.

Found on moflix-stream.xyz, for example: `https://moflix-stream.xyz/watch/1636480`
