### PR TITLE
FlyFile: add flyf.lat mirror and fix API host

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/flyfile.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/flyfile.py
@@ -24,8 +24,8 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class FlyFileResolver(ResolveUrl):
     name = 'FlyFile'
-    domains = ['flyfile.app']
-    pattern = r'(?://|\.)(flyfile\.app)/embed/([A-Za-z0-9]+)'
+    domains = ['flyfile.app', 'flyf.lat']
+    pattern = r'(?://|\.)(flyfile\.app|flyf\.lat)/embed/([A-Za-z0-9]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)
@@ -34,7 +34,8 @@ class FlyFileResolver(ResolveUrl):
             'Referer': web_url,
             'Origin': urllib_parse.urljoin(web_url, '/')[:-1]
         }
-        assign_url = 'https://api.{0}/api/streaming/assign/{1}'.format(host, media_id)
+        # The API lives on flyfile.app for every player mirror; api.flyf.lat does not exist
+        assign_url = 'https://api.flyfile.app/api/streaming/assign/{0}'.format(media_id)
         data = self.net.http_GET(assign_url, headers=headers).json
         if data.get('url') and data.get('token'):
             stream_url = '{0}/hls/{1}/master.m3u8'.format(


### PR DESCRIPTION
flyf.lat is a player mirror of flyfile.app. Same embed layout, same /embed/<id> path, same backend — but the domain is not in the resolver, so the link is dropped before it is ever tried.

Two changes are needed:

Add flyf.lat to domains and to pattern.
The assign endpoint is currently built from the host, `'https://api.{0}/...'.format(host)`. For this mirror that yields api.flyf.lat, which does not resolve — the API only exists on api.flyfile.app, and it serves the IDs of both mirrors. So the host is dropped from that URL.

Tested against a live link:

`https://flyf.lat/embed/pZR0m645eB8fdH3`
  -> api.flyfile.app/api/streaming/assign/...
     200, url + token
  -> streaming-us-4.flyfile.app/hls/<token>/master.m3u8
     200, 2 audio renditions (de/en)
  -> 720p/index.m3u8
     200, 1230 segments
  -> first segment 2378388 bytes, magic 0x47
     ffprobe: mpegts, h264 1694x720

Also verified playing in Kodi 21.3 on Android, including the separate audio renditions.

flyfile.app links keep resolving unchanged. Negative checks (flyf.la, xflyf.lat, flyf.lat.<other>.com, flyfile.apps, bare host) are all rejected.

Found on moflix-stream.xyz, for example: `https://moflix-stream.xyz/watch/1636480`