### PR TITLE
vidsonic add vixeo.io and new player config format

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/vidsonic.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vidsonic.py
@@ -16,7 +16,9 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
+import base64
 import binascii
+import json
 import re
 from six.moves import urllib_parse
 from resolveurl.lib import helpers
@@ -26,8 +28,8 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class VidSonicResolver(ResolveUrl):
     name = 'VidSonic'
-    domains = ['vidsonic.net']
-    pattern = r'(?://|\.)(vidsonic\.net)/(?:e|d)/([0-9a-zA-Z]+)'
+    domains = ['vidsonic.net', 'vixeo.io']
+    pattern = r'(?://|\.)(vidsonic\.net|vixeo\.io)/(?:e|d)/([0-9a-zA-Z]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)
@@ -38,9 +40,20 @@ class VidSonicResolver(ResolveUrl):
             'Origin': ref[:-1]
         }
         html = self.net.http_GET(web_url, headers=headers).content
+        src = ''
         r = re.search(r"const\s*_0x1\s*=\s*'([^']+)", html)
         if r:
-            src = binascii.unhexlify(r.group(1).replace('|', '')).decode()[::-1]
+            src = r.group(1)
+        else:
+            # newer player builds carry the same reversed hex string in a
+            # base64 encoded json blob on the player root element instead
+            r = re.search(r'data-config="([^"]+)"', html)
+            if r:
+                blob = r.group(1)
+                cfg = json.loads(base64.b64decode(blob + '=' * (-len(blob) % 4)))
+                src = cfg.get('source', '')
+        if src:
+            src = binascii.unhexlify(src.replace('|', '')).decode()[::-1]
             return src + helpers.append_headers(headers)
         raise ResolverError('Video Link Not Found')
 

--- a/script.module.resolveurl/lib/resolveurl/plugins/vidsonic.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vidsonic.py
@@ -16,7 +16,6 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-import base64
 import binascii
 import json
 import re
@@ -29,7 +28,7 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 class VidSonicResolver(ResolveUrl):
     name = 'VidSonic'
     domains = ['vidsonic.net', 'vixeo.io']
-    pattern = r'(?://|\.)(vidsonic\.net|vixeo\.io)/(?:e|d)/([0-9a-zA-Z]+)'
+    pattern = r'(?://|\.)((?:vidsonic|vixeo)\.(?:net|io))/(?:e|d)/([0-9a-zA-Z]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)
@@ -50,7 +49,7 @@ class VidSonicResolver(ResolveUrl):
             r = re.search(r'data-config="([^"]+)"', html)
             if r:
                 blob = r.group(1)
-                cfg = json.loads(base64.b64decode(blob + '=' * (-len(blob) % 4)))
+                cfg = json.loads(helpers.b64decode(blob))
                 src = cfg.get('source', '')
         if src:
             src = binascii.unhexlify(src.replace('|', '')).decode()[::-1]


### PR DESCRIPTION
vixeo.io is a VidSonic front domain. Same file id resolves on both hosts and
returns the same title, while a made up id fails on both, so it is the same
backend rather than a separate service.

It ships a newer player build though, so adding the domain alone is not
enough. The old build exposes the reversed hex string as `const _0x1` in the
page. The new one base64 encodes a small json blob into the `data-config`
attribute of the player root element and carries the very same string in its
`source` field. The decoding is unchanged: strip the pipes, unhexlify,
reverse. The existing branch is tried first, so nothing changes for pages
still on the old build.

Tested against `https://vixeo.io/e/yKJm8qBdl6xh` (embedded on filmpalast.to):
resolves to a signed m3u8 on sfy-01-fr.vidsonic.net, playlist and first
segment both return 200, and the segment is real MPEG-TS (0x47 sync on every
188 byte boundary, h264 1280x720 + aac). No referer lock on the embed page.

One limitation worth flagging: on vidsonic.net itself the old branch currently
returns the relative path /uploads/<id>.mp4, which 404s when resolved against
the host, so that path does not play. That is unrelated to this change and
behaves identically before and after the patch — I have not touched it since
I could not yet tell whether it affects the platform generally or just
individual migrated files.

Tested on Kodi 21.3 64 bit Android 16