### PR TITLE
streamix add odysseusa.cc domain

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/streamix.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/streamix.py
@@ -27,10 +27,10 @@ class StreamixResolver(ResolveUrl):
     name = 'Streamix'
     domains = [
         'streamix.so', 'stmix.io', 'vidara.so', 'vidara.to', 'vidaraa.cc', 'vidmatrixa.com',
-        'kinoger.pw', 'viewdara.com', 'thebesthosterv.com'
+        'kinoger.pw', 'viewdara.com', 'thebesthosterv.com', 'odysseusa.cc'
     ]
     pattern = (
-        r'(?://|\.)((?:st(?:rea)?mix|vid(?:ar|matrix)a*|viewdara|thebesthosterv|kinoger)'
+        r'(?://|\.)((?:st(?:rea)?mix|vid(?:ar|matrix)a*|viewdara|thebesthosterv|kinoger|odysseusa)'
         r'\.(?:so|io|to|cc|com|pw))/(?:e|v)/([0-9a-zA-Z]+)'
     )
 


### PR DESCRIPTION
Adds odysseusa.cc, another Vidara front domain for some VIDARA links.

Sample: `https://odysseusa.cc/e/rTLh4yuM5OLDJ`

Tested on Android 16, Kodi 21.3 64-bit.