### PR TITLE
streamix additional domain

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/streamix.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/streamix.py
@@ -27,11 +27,11 @@ class StreamixResolver(ResolveUrl):
     name = 'Streamix'
     domains = [
         'streamix.so', 'stmix.io', 'vidara.so', 'vidara.to', 'vidaraa.cc', 'vidmatrixa.com',
-        'kinoger.pw', 'viewdara.com', 'thebesthosterv.com', 'odysseusa.cc'
+        'kinoger.pw', 'viewdara.com', 'thebesthosterv.com', 'odysseusa.cc', 'ano.cx'
     ]
     pattern = (
-        r'(?://|\.)((?:st(?:rea)?mix|vid(?:ar|matrix)a*|viewdara|thebesthosterv|kinoger|odysseusa)'
-        r'\.(?:so|io|to|cc|com|pw))/(?:e|v)/([0-9a-zA-Z]+)'
+        r'(?://|\.)((?:st(?:rea)?mix|vid(?:ar|matrix)a*|viewdara|thebesthosterv|kinoger|odysseusa|ano)'
+        r'\.(?:so|io|to|cc|com|pw|cx))/(?:e|v)/([0-9a-zA-Z]+)'
     )
 
     def get_media_url(self, host, media_id, subs=False):


### PR DESCRIPTION
Adds ano.cx, another Streamix domain.

It uses the same POST /api/stream endpoint with {filecode, device} and returns the same JSON shape, and the same file id resolves to an identical stream path on vidara.to and odysseusa.cc, both already listed. A made-up id returns 404 on all of them.

Sample links (working at the time of writing, embedded on kellerkino.com):

https://ano.cx/e/06bec11921e3
https://ano.cx/e/0932385304c6
https://ano.cx/e/11b6f34c71fe

Tested through the resolver with the patch applied: master playlist, child playlist and the first segment all load, the segment starts with 0x47.