### PR TITLE
voe additional domain

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
@@ -60,7 +60,7 @@ class VoeResolver(ResolveUrl):
         'kinoger.ru', 'johnbeyondnation.com', 'jeanprofessorcentral.com', 'juliewomanwish.com',
         'garylargeavailable.com', 'jennifereconomicgive.com', 'pamelachangemission.com',
         'ellenpoliticalfollow.com', 'caseyimpactstation.com', 'matthewhotelscience.com',
-        'jessicachoosemake.com', 'stevenfamilyedge.com', 'tracylocalschool.com'
+        'jessicachoosemake.com', 'stevenfamilyedge.com', 'tracylocalschool.com', 'eugenemakedraw.com'
     ]
     domains += ['voeunblock{}.com'.format(x) for x in range(1, 11)]
     pattern = (
@@ -90,7 +90,7 @@ class VoeResolver(ResolveUrl):
         r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|johnbeyondnation|'
         r'jeanprofessorcentral|juliewomanwish|garylargeavailable|jennifereconomicgive|'
         r'pamelachangemission|ellenpoliticalfollow|caseyimpactstation|matthewhotelscience|'
-        r'jessicachoosemake|stevenfamilyedge|tracylocalschool|'
+        r'jessicachoosemake|stevenfamilyedge|tracylocalschool|eugenemakedraw|'
         r'(?:v-?o-?e)?(?:-?un-?bl[o0]?c?k\d{0,2})?(?:-?voe)?)\.(?:sx|com|net|cc|me|ru))/'
         r'(?:e/)?([0-9A-Za-z]+)'
     )


### PR DESCRIPTION
Adds eugenemakedraw.com, a current VOE front domain that is not covered yet.

tracylocalschool.com, which is already listed, serves a small JS redirect page pointing to eugenemakedraw.com for every valid file id. The same file id returns the identical VOE player page on both domains, while a made-up id returns a 404, so this is the same platform and not just a lookalike frontend.

Both the domain list and the pattern need the entry, otherwise the resolver is filtered out before valid_url() is reached.

Sample links (working at the time of writing, embedded on kellerkino.com):
```
https://eugenemakedraw.com/e/5dunxepcpd42
https://eugenemakedraw.com/e/8vie8ecd5f6o
https://eugenemakedraw.com/e/byt1lkf8squ9
```
Tested with the patch applied: all six samples I tried resolved, and the returned mp4 answers with HTTP 200 and a valid ftyp box.