### PR TITLE
streamix additional domains

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/streamix.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/streamix.py
@@ -27,11 +27,11 @@ class StreamixResolver(ResolveUrl):
     name = 'Streamix'
     domains = [
         'streamix.so', 'stmix.io', 'vidara.so', 'vidara.to', 'vidaraa.cc', 'vidmatrixa.com',
-        'kinoger.pw', 'viewdara.com', 'thebesthosterv.com', 'odysseusa.cc'
+        'kinoger.pw', 'viewdara.com', 'thebesthosterv.com', 'odysseusa.cc', 'ano.cx', 'vidwara.cc'
     ]
     pattern = (
-        r'(?://|\.)((?:st(?:rea)?mix|vid(?:ar|matrix)a*|viewdara|thebesthosterv|kinoger|odysseusa)'
-        r'\.(?:so|io|to|cc|com|pw))/(?:e|v)/([0-9a-zA-Z]+)'
+        r'(?://|\.)((?:st(?:rea)?mix|vid(?:w?ar|matrix)a*|viewdara|thebesthosterv|kinoger|odysseusa|ano)'
+        r'\.(?:so|io|to|cc|com|pw|cx))/(?:e|v)/([0-9a-zA-Z]+)'
     )
 
     def get_media_url(self, host, media_id, subs=False):


### PR DESCRIPTION
ano.cx is an entry alias — its player page runs a client-side mirror check (MIRROR_ORIGIN = `https://vidwara.cc`) and jumps to vidwara.cc in a browser. There is no HTTP redirect, and POST /api/stream answers on both domains with the same JSON shape the plugin already parses, so the resolver works on either one.

Same platform: one file id returns the identical stream path via /api/stream on ano.cx, vidwara.cc, vidara.to, vidara.so, vidaraa.cc and odysseusa.cc, and a made-up id returns 404 on all of them.

Pattern changes: vid(?:ar|matrix)a* → vid(?:w?ar|matrix)a* for vidwara, plus |ano and cx for ano.cx.

Sample links (working at the time of writing, embedded on kellerkino.com):
```
https://vidwara.cc/e/0932385304c6
https://vidwara.cc/e/15fe896da06f
https://ano.cx/e/0932385304c6
https://ano.cx/e/199d49117171
```
Tested through the resolver with the patch applied: master playlist, child playlist and first segment load for all samples, segments start with 0x47.