### PR TITLE
2Captcha Implementation

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/__init__.py
+++ b/script.module.resolveurl/lib/resolveurl/__init__.py
@@ -315,6 +315,7 @@ def _update_settings_xml():
         '\t\t<setting default="false" id="bp_enable" label="%s" type="bool"/>' % (common.i18n('enable_byparr')),
         '\t\t<setting id="bp_url" visible="eq(-1,true)" enable="eq(-1,true)" type="text" label="%s" default="http://localhost:8191"/>' % (common.i18n('byparr_url')),
         '\t\t<setting id="bp_timeout" visible="eq(-2,true)" enable="eq(-2,true)" type="slider" label="%s" default="60" range="30,30,180" option="int" />' % (common.i18n('byparr_timeout')),
+        '\t\t<setting id="twocaptcha_key" type="text" label="%s" option="hidden" default=""/>' % (common.i18n('twocaptcha_key')),
         '\t\t<setting id="personal_nid" label="Your NID" type="text" visible="false" default=""/>',
         '\t\t<setting id="last_ua_create" label="last_ua_create" type="number" visible="false" default="0"/>',
         '\t\t<setting id="current_ua" label="current_ua" type="text" visible="false" default=""/>',

--- a/script.module.resolveurl/lib/resolveurl/lib/captcha_lib.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/captcha_lib.py
@@ -24,9 +24,11 @@ import os
 from resolveurl.lib import recaptcha_v2
 from resolveurl.lib import helpers
 import base64
+import json
 
 net = common.Net()
 IMG_FILE = 'captcha_img.gif'
+TWOCAPTCHA_API = 'https://api.2captcha.com'
 
 
 def get_response(img, x=450, y=225, w=400, h=130):
@@ -130,6 +132,52 @@ def do_recaptcha_v2(sitekey):
         return {'g-recaptcha-response': token}
 
     return {}
+
+
+def do_turnstile(sitekey, page_url, timeout=120):
+    """
+    Solve a standalone Cloudflare Turnstile widget through the 2Captcha API
+    (createTask / getTaskResult). Turnstile cannot be solved in pure python,
+    so the token is bought from the service using the API key from the
+    addon settings. Returns the form fields to POST back to the site
+    (Turnstile fills both names in reCAPTCHA compatibility mode) or an
+    empty dict if no API key is configured.
+    """
+    api_key = common.get_setting('twocaptcha_key')
+    if not api_key:
+        return {}
+
+    common.logger.log_debug('Cloudflare Turnstile via 2Captcha: %s' % sitekey)
+    common.kodi.notify(msg=common.i18n('solving_captcha'), duration=8000)
+    headers = {'User-Agent': common.SMR_USER_AGENT}
+    task = {
+        'clientKey': api_key,
+        'task': {
+            'type': 'TurnstileTaskProxyless',
+            'websiteURL': page_url,
+            'websiteKey': sitekey
+        }
+    }
+    resp = json.loads(net.http_POST(TWOCAPTCHA_API + '/createTask', form_data=task, headers=headers, jdata=True).content)
+    if resp.get('errorId'):
+        raise Exception('2Captcha: %s' % resp.get('errorCode', 'createTask failed'))
+
+    result = {'clientKey': api_key, 'taskId': resp.get('taskId')}
+    waited = 0
+    # the service asks for the first poll after 5 seconds and 5 seconds between polls
+    while waited < timeout:
+        common.kodi.sleep(5000)
+        waited += 5
+        resp = json.loads(net.http_POST(TWOCAPTCHA_API + '/getTaskResult', form_data=result, headers=headers, jdata=True).content)
+        if resp.get('errorId'):
+            raise Exception('2Captcha: %s' % resp.get('errorCode', 'getTaskResult failed'))
+        if resp.get('status') == 'ready':
+            token = resp.get('solution', {}).get('token')
+            if token:
+                return {'cf-turnstile-response': token, 'g-recaptcha-response': token}
+            break
+
+    raise Exception('2Captcha: no Turnstile token received')
 
 
 def do_xfilecaptcha(captcha_url):

--- a/script.module.resolveurl/lib/resolveurl/lib/strings.py
+++ b/script.module.resolveurl/lib/resolveurl/lib/strings.py
@@ -123,5 +123,7 @@ STRINGS = {
     'cl_background': 33103,
     'enable_byparr': 33104,
     'byparr_url': 33105,
-    'byparr_timeout': 33106
+    'byparr_timeout': 33106,
+    'twocaptcha_key': 33107,
+    'solving_captcha': 33108
 }

--- a/script.module.resolveurl/lib/resolveurl/plugins/dropload.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/dropload.py
@@ -16,8 +16,14 @@
     along with this program.  If not, see <http://www.gnu.org/licenses/>.
 """
 
-from resolveurl.plugins.__resolve_generic__ import ResolveGeneric
+import re
+from six.moves import urllib_parse
+
+from resolveurl import common
+from resolveurl.lib import captcha_lib
 from resolveurl.lib import helpers
+from resolveurl.plugins.__resolve_generic__ import ResolveGeneric
+from resolveurl.resolver import ResolverError
 
 
 class DropLoadResolver(ResolveGeneric):
@@ -26,12 +32,38 @@ class DropLoadResolver(ResolveGeneric):
     pattern = r'(?://|\.)(dr[0o]p(?:load|stream)\.(?:io|tv|com?|pro))/(?:embed-|e/|d/)?([0-9a-zA-Z]+)'
 
     def get_media_url(self, host, media_id):
-        return helpers.get_media_url(
-            self.get_url(host, media_id),
+        web_url = self.get_url(host, media_id)
+        headers = {'User-Agent': common.RAND_UA}
+        response = self.net.http_GET(web_url, headers=headers)
+        html = response.content
+        # the embed page is gated by a Cloudflare Turnstile widget (reCAPTCHA
+        # compatibility mode) whose form posts back to the embed page;
+        # the player is only served after a valid token has been posted
+        sitekey = re.search(r'''class=["']g-recaptcha["'][^>]+data-sitekey=["']([^"']+)''', html)
+        if sitekey:
+            web_url = response.get_url()  # secondary domains redirect to the main one
+            captcha = captcha_lib.do_turnstile(sitekey.group(1), web_url)
+            if not captcha:
+                raise ResolverError('DropLoad requires a 2Captcha API key, see ResolveURL settings')
+            data = helpers.get_hidden(html)
+            data.update(captcha)
+            rurl = urllib_parse.urljoin(web_url, '/')
+            headers.update({'Referer': web_url, 'Origin': rurl[:-1]})
+            html = self.net.http_POST(web_url, form_data=data, headers=headers).content
+
+        rurl = urllib_parse.urljoin(web_url, '/')
+        headers.update({'Referer': rurl, 'Origin': rurl[:-1]})
+        sources = helpers.scrape_sources(
+            html,
             patterns=[r'''sources:\s*\[{\s*file:\s*["'](?P<url>[^"']+)'''],
             generic_patterns=False,
-            referer=False
+            url=web_url
         )
+        if sources:
+            source = helpers.pick_source(sources)
+            return urllib_parse.quote(source, '/:?=&!') + helpers.append_headers(headers)
+
+        raise ResolverError('Unable to locate stream URL.')
 
     def get_url(self, host, media_id):
         return self._default_get_url(host, media_id, template='https://{host}/e/{media_id}')

--- a/script.module.resolveurl/resources/language/resource.language.en_gb/strings.po
+++ b/script.module.resolveurl/resources/language/resource.language.en_gb/strings.po
@@ -440,3 +440,11 @@ msgstr ""
 msgctxt "#33106"
 msgid "ByParr timeout"
 msgstr ""
+
+msgctxt "#33107"
+msgid "2Captcha API Key"
+msgstr ""
+
+msgctxt "#33108"
+msgid "Solving Captcha, please wait"
+msgstr ""


### PR DESCRIPTION
# description

dr0pstream.com put a standalone Cloudflare Turnstile widget in front of every embed path (#1481). The widget runs in reCAPTCHA compatibility mode (`api.js?compat=recaptcha`), the form posts `op=embed`, `file_code` and the token back to the embed URL, and the player page then carries the sources in a packed jwplayer setup.

This PR adds optional 2Captcha support and uses it in the DropLoad plugin - same idea as the ByParr setting, as a hosted service. Measurements and reasoning are in #1481.

**Changes**

- `lib/resolveurl/__init__.py`: new optional setting `twocaptcha_key` (text, masked, default empty) in the ResolveURL category after the ByParr settings
- `lib/resolveurl/lib/captcha_lib.py`: `do_turnstile(sitekey, page_url)` - createTask/getTaskResult against api.2captcha.com (`TurnstileTaskProxyless`, poll 5 s, timeout 120 s), notification "Solving Captcha, please wait" while it runs, returns the `cf-turnstile-response` / `g-recaptcha-response` fields or `{}` without a key
- `lib/resolveurl/lib/strings.py`, `resources/language/resource.language.en_gb/strings.po`: ids 33107 "2Captcha API Key", 33108 "Solving Captcha, please wait"
- `lib/resolveurl/plugins/dropload.py`: detect the widget, fetch the token, POST the hidden fields + token to the embed URL (final host after the dropload.co/.pro redirect), scrape the sources via `helpers.scrape_sources` (unpacks the packed setup); without a key a clear ResolverError, without the gate the old path

**Setup**: Settings -> ResolveURL -> first tab "ResolveURL" -> "2Captcha API Key" (directly under "Enable ByParr access", or under "ByParr timeout" when ByParr is enabled; masked input). Key is global, entered once; the solving itself has to be wired per plugin - find the sitekey, `captcha_lib.do_turnstile(sitekey, page_url)`, POST the hidden fields plus the returned dict. This PR wires DropLoad only.

**Tested**: sandbox with the real plugin on `y5gc8a1dj600` (issue), `1srjaaed9it5`, `22bw0d6w3uy3` (kinoger.to) - master.m3u8 -> child -> first .ts segment; Kodi on Android with DropLoad links from a German streaming site - plays, fast. Negative cases: no key -> ResolverError, wrong key -> `2Captcha: ERROR_KEY_DOES_NOT_EXIST`, fake token -> gate again -> "Unable to locate stream URL".

**Cost**: 0.00145 USD per solve (single-use token, one solve per resolve), a 10 USD top-up is roughly 6,900 resolves.

**Limits**: only the en_gb labels are added, the other language files still need 33107/33108; the poll blocks for the solve time; addon.xml/changelog untouched.