### PR TITLE
FireStream added firestream.site

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/firestream.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/firestream.py
@@ -25,8 +25,8 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class FireStreamResolver(ResolveUrl):
     name = 'FireStream'
-    domains = ['firestream.to']
-    pattern = r'(?://|\.)(firestream\.to)/(?:e|v)/([0-9a-zA-Z_-]+)'
+    domains = ['firestream.to', 'firestream.site']
+    pattern = r'(?://|\.)(firestream\.(?:to|site))/(?:e|v)/([0-9a-zA-Z_-]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)


### PR DESCRIPTION
Some sites now embed FireStream links on `firestream.site`, which the plugin doesn't
match — only `firestream.to` is listed. The domain list and the pattern both need the
second domain, so this adds it to both.

Sample link: https://firestream.site/e/g8N7Wbth

Evidence that it's the same platform and not a lookalike: the same file id serves on both
domains with identical response size and the same `originalName` in the player, while a
made-up id gives a byte-identical 404 on both.

| file id | firestream.site | firestream.to |
|---|---|---|
| `g8N7Wbth` | 200, 78795 bytes, `Auch Liebe.mp4` | 200, 78795 bytes, same name |
| `BBUoHgYP` | 200, 743843 bytes, `Exhuma.2024.51.1080p.BluRay.mp4` | identical |
| `nZK8nc7X` | 200, 743855 bytes, `The.Old.Guard.2.2025.51.1080p.WEB.mp4` | identical |

No redirect is involved: `firestream.site` answers on its own, and the `location.href` in
the player points at `window.location.origin`, so it stays on whichever domain was opened.

With the patch, `/e/` and `/v/` links resolve on both domains and the returned url serves
a valid HLS playlist. Existing `firestream.to` links behave exactly as before, and
near-miss domains (`firestream.xyz`, `firestreamer.site`) stay unmatched.

Worth mentioning: the CDN hands out sporadic 403s. They hit either domain and move
between attempts — the same id that failed once resolved fine on the next try, so it
looks like rate limiting rather than anything domain specific.

```diff
--- a/lib/resolveurl/plugins/firestream.py
+++ b/lib/resolveurl/plugins/firestream.py
@@ -25,8 +25,8 @@
 class FireStreamResolver(ResolveUrl):
     name = 'FireStream'
-    domains = ['firestream.to']
-    pattern = r'(?://|\.)(firestream\.to)/(?:e|v)/([0-9a-zA-Z_-]+)'
+    domains = ['firestream.to', 'firestream.site']
+    pattern = r'(?://|\.)(firestream\.(?:to|site))/(?:e|v)/([0-9a-zA-Z_-]+)'
```
