### PR TITLE
Fix VK resolver crash and add missing MixDrop mirror domains

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/mixdrop.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/mixdrop.py
@@ -32,7 +32,8 @@ class MixDropResolver(ResolveUrl):
         'mixdrop21.net', 'mixdrop.is', 'mixdrop.si', 'mixdrop23.net', 'mixdrop.nu',
         'mixdrop.ms', 'mdzsmutpcvykb.net', 'mixdrop.ps', 'mxdrop.to', 'mixdrop.sb',
         'mixdrop.my', 'm1xdrop.net', 'm1xdrop.com', 'm1xdrop.click', 'mxdrop.sx',
-        'mixdrop.top', 'mixdrp.click', 'miixdrop.net'
+        'mixdrop.top', 'mixdrp.click', 'miixdrop.net', 'miiixdrop.net',
+        'miiiixdrop.net'
     ]
     pattern = (
         r'(?://|\.)((?:mi*1*xdro*p\d*(?:jmk)?|md(?:3b0j6hj|bekjwqa|fx9dc8n|y48tn97|zsmutpcvykb))\.'

--- a/script.module.resolveurl/lib/resolveurl/plugins/vk.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vk.py
@@ -31,7 +31,7 @@ class VKResolver(ResolveUrl):
 
     def get_media_url(self, host, media_id):
         ref = 'https://{0}/'.format(host)
-        headers = {'User-Agent': common.EDGE_USER_AGENT,
+        headers = {'User-Agent': common.RAND_UA,
                    'Referer': ref,
                    'Origin': ref[:-1]}
 

--- a/script.module.resolveurl/lib/resolveurl/plugins/vk.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vk.py
@@ -31,7 +31,7 @@ class VKResolver(ResolveUrl):
 
     def get_media_url(self, host, media_id):
         ref = 'https://{0}/'.format(host)
-        headers = {'User-Agent': common.RAND_UA,
+        headers = {'User-Agent': common.EDGE_USER_AGENT,
                    'Referer': ref,
                    'Origin': ref[:-1]}
 
@@ -103,7 +103,11 @@ class VKResolver(ResolveUrl):
         if payload:
             for item in payload:
                 if isinstance(item, dict):
-                    js_data = item.get('player').get('params')[0]
+                    player = item.get('player')
+                    if isinstance(player, dict):
+                        params = player.get('params')
+                        if params:
+                            js_data = params[0]
             for item in list(js_data.keys()):
                 if item.startswith('url'):
                     sources.append((item[3:], js_data.get(item)))


### PR DESCRIPTION
**Fix: AttributeError: 'NoneType' object has no attribute 'get' in VK resolver**

VKResolver.__get_sources() assumed every dict item in the payload list from VK's al_video.php response contains a "player" key. In practice, some payload items (e.g. non-player metadata entries) don't have one, so item.get('player') returns None, and the immediate .get('params') call raises an AttributeError, crashing the resolve even when another item in the same payload does contain valid player data.

This fix only processes payload items that actually have a dict "player" value with a non-empty "params" list, skipping anything else instead of raising. If no valid item is found, __get_sources() now falls back gracefully to the existing playerParams HTML-regex path in get_media_url(), instead of throwing before that fallback ever gets a chance to run.

No behavior change for the happy path — only adds resilience against VK's inconsistent payload shape.

```diff
         if payload:
             for item in payload:
                 if isinstance(item, dict):
-                    js_data = item.get('player').get('params')[0]
+                    player = item.get('player')
+                    if isinstance(player, dict):
+                        params = player.get('params')
+                        if params:
+                            js_data = params[0]
             for item in list(js_data.keys()):
```
_________________________________________________________________________

**Add missing MixDrop mirror domains (miiixdrop.net, miiiixdrop.net)**

The pattern regex (mi*1*xdro*p...) already matches any number of repeated "i"s in the MixDrop mirror subdomain, but the static domains list only goes up to miixdrop.net (two "i"s). Since relevant_resolvers() filters candidate resolvers by checking membership against domains before the regex is ever tested, a real, currently-active mirror like miiiixdrop.net (three "i"s) is filtered out early and never reaches the resolver at all — even though the pattern itself would have matched it.

This adds the missing three- and four-"i" variants observed in the wild, consistent with the existing naming convention in the list.

```diff
         'mixdrop21.net', 'mixdrop.is', 'mixdrop.si', 'mixdrop23.net', 'mixdrop.nu',
         'mixdrop.ms', 'mdzsmutpcvykb.net', 'mixdrop.ps', 'mxdrop.to', 'mixdrop.sb',
         'mixdrop.my', 'm1xdrop.net', 'm1xdrop.com', 'm1xdrop.click', 'mxdrop.sx',
-        'mixdrop.top', 'mixdrp.click', 'miixdrop.net'
+        'mixdrop.top', 'mixdrp.click', 'miixdrop.net', 'miiixdrop.net',
+        'miiiixdrop.net'
     ]
```