### PR TITLE
voesx-additional-domain

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/voesx.py
@@ -60,7 +60,7 @@ class VoeResolver(ResolveUrl):
         'kinoger.ru', 'johnbeyondnation.com', 'jeanprofessorcentral.com', 'juliewomanwish.com',
         'garylargeavailable.com', 'jennifereconomicgive.com', 'pamelachangemission.com',
         'ellenpoliticalfollow.com', 'caseyimpactstation.com', 'matthewhotelscience.com',
-        'jessicachoosemake.com', 'stevenfamilyedge.com', 'tracylocalschool.com', 'eugenemakedraw.com'
+        'jessicachoosemake.com', 'stevenfamilyedge.com', 'tracylocalschool.com', 'eugenemakedraw.com', 'johnfullwonder.com'
     ]
     domains += ['voeunblock{}.com'.format(x) for x in range(1, 11)]
     pattern = (
@@ -90,7 +90,7 @@ class VoeResolver(ResolveUrl):
         r'charlestoughrace|ianrequireadult|timmaybealready|jessicayeahcatch|kinoger|johnbeyondnation|'
         r'jeanprofessorcentral|juliewomanwish|garylargeavailable|jennifereconomicgive|'
         r'pamelachangemission|ellenpoliticalfollow|caseyimpactstation|matthewhotelscience|'
-        r'jessicachoosemake|stevenfamilyedge|tracylocalschool|eugenemakedraw|'
+        r'jessicachoosemake|stevenfamilyedge|tracylocalschool|eugenemakedraw|johnfullwonder|'
         r'(?:v-?o-?e)?(?:-?un-?bl[o0]?c?k\d{0,2})?(?:-?voe)?)\.(?:sx|com|net|cc|me|ru))/'
         r'(?:e/)?([0-9A-Za-z]+)'
     )


### PR DESCRIPTION
johnfullwonder.com is the current VOE front domain. The previously added eugenemakedraw.com now only serves the small "Redirecting..." JS page that sends the browser to johnfullwonder.com (tracylocalschool.com -> 302 -> eugenemakedraw.com -> JS -> johnfullwonder.com). The resolver still works through the old domains because it follows that redirect, but links that point to johnfullwonder.com directly are not matched.

Same file id on both domains, made-up id gives the same 302 to voe.sx on both. No JS mirror jump on johnfullwonder.com itself (it is the destination, not an alias).

Sample links (all resolved to the mp4 on the CDN with the patch):
```
https://johnfullwonder.com/e/bdkpupoamztm
https://johnfullwonder.com/e/qvljmdr8kwiq
https://johnfullwonder.com/e/cbh0tdc07stb
```