### PR TITLE
streamtape-additional-domains

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/streamtape.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/streamtape.py
@@ -31,13 +31,16 @@ class StreamTapeResolver(ResolveUrl):
         'streamadblockplus.com', 'shavetape.cash', 'streamtape.to', 'streamta.site',
         'streamadblocker.xyz', 'tapewithadblock.org', 'adblocktape.wiki', 'antiadtape.com',
         'streamtape.xyz', 'tapeblocker.com', 'streamnoads.com', 'tapeadvertisement.com',
-        'tapeadsenjoyer.com', 'watchadsontape.com', 'tpead.net', 'advertape.net'
+        'tapeadsenjoyer.com', 'watchadsontape.com', 'tpead.net', 'advertape.net',
+        'strtape.site', 'strtapeadblock.me', 'gettapeads.com',
+        'streamtapeadblock.art', 'streamtapeadblockuser.xyz', 'advtpe.com'
     ]
     pattern = (
-        r'(?://|\.)((?:s(?:tr)?(?:eam|have)?|tapewith|watchadson|adver)'
+        r'(?://|\.)((?:(?:stream|str)tapeadblock(?:user)?|gettapeads|advtpe|'
+        r'(?:s(?:tr)?(?:eam|have)?|tapewith|watchadson|adver)'
         r'?(?:adblock(?:er|plus)?|antiad|noads)?'
-        r'(?:ta?p?e?|cloud)?(?:blocker|advertisement|adsenjoyer|ad)?\.'
-        r'(?:com|cloud|net|pe|site|link|cc|online|fun|cash|to|xyz|org|wiki|club)'
+        r'(?:ta?p?e?|cloud)?(?:blocker|advertisement|adsenjoyer|ad)?)\.'
+        r'(?:com|cloud|net|pe|site|link|cc|online|fun|cash|to|xyz|org|wiki|club|me|art)'
         r')/(?:e|v)/([0-9a-zA-Z]+)'
     )
 


### PR DESCRIPTION
Adds six StreamTape front domains that are currently in use but not covered.

All six serve the same files as the listed domains. Same file id returns the same
video with the same original filename in the page title, and `resolve()` ends on the
same `tapecontent.net` CDN path for that id:

| domain | sample |
|---|---|
| strtape.site | https://strtape.site/v/GvYW6pvM2LC17pK |
| strtapeadblock.me | https://strtapeadblock.me/v/2LaM4zrGM3uZ0Mg |
| gettapeads.com | https://gettapeads.com/v/GvYW6pvM2LC17pK |
| streamtapeadblock.art | https://streamtapeadblock.art/v/GvYW6pvM2LC17pK |
| streamtapeadblockuser.xyz | https://streamtapeadblockuser.xyz/v/2LaM4zrGM3uZ0Mg |
| advtpe.com | https://advtpe.com/v/2LaM4zrGM3uZ0Mg |

A made up id returns the same 404 page on all six, so the ids are really being looked
up rather than echoed back.

`advtpe.com` is the adblock fallback the other five jump to: their player page carries
`location.href = location.href.replace(..., "https://advtpe.com/")`, which fires when an
ad blocker is detected. Without it in the list the fallback ends up unresolvable, so it
belongs in the same change.

One note on the pattern: `strtape.site` already matched it, only the domains list was
missing it — `relevant_resolvers()` filters on the list before the pattern is ever
tested. The other five needed both. I put the new names in front of the existing
alternation instead of loosening the existing groups, so the current logic is untouched;
`me` and `art` are added to the TLD group.

Checked against the current master: all 27 existing domains still resolve to StreamTape,
`/e/` and `/v/` both still work, and a set of lookalike domains (streamtapeadblockuserx.com,
advtpex.com, gettapeadsx.net, notstrtape.site, xstrtapeadblock.me) stays unmatched. I also
ran the new pattern against every domain listed in all other plugins — it picks up none of
them.