### PR TITLE
vidsonic additional domain

### DIFF
--- a/script.module.resolveurl/lib/resolveurl/plugins/vidsonic.py
+++ b/script.module.resolveurl/lib/resolveurl/plugins/vidsonic.py
@@ -27,8 +27,8 @@ from resolveurl.resolver import ResolveUrl, ResolverError
 
 class VidSonicResolver(ResolveUrl):
     name = 'VidSonic'
-    domains = ['vidsonic.net', 'vixeo.io']
-    pattern = r'(?://|\.)((?:vidsonic|vixeo)\.(?:net|io))/(?:e|d)/([0-9a-zA-Z]+)'
+    domains = ['vidsonic.net', 'vixeo.io', 'vsonic.click']
+    pattern = r'(?://|\.)((?:v(?:id)?sonic|vixeo)\.(?:net|io|click))/(?:e|d)/([0-9a-zA-Z]+)'
 
     def get_media_url(self, host, media_id):
         web_url = self.get_url(host, media_id)


### PR DESCRIPTION
Adds `vsonic.click`, another front domain for VidSonic.

Same platform, verified with shared file ids: six ids taken from vidsonic.net links
return byte-identical pages on both domains, and a made up id returns the same
byte-identical "Video Not Found" page (2544 bytes) on both.

| id | vidsonic.net | vsonic.click |
|---|---|---|
| 2JHCeFB2kZ59 | 136941 | 136941 |
| 2rgHyUKf3L2f | 136935 | 136935 |
| 5WiRwAgSHkXR | 136937 | 136937 |
| 5b54t4tzp9c2 | 146455 | 146455 |
| 6BARjW9Yyvu0 | 136913 | 136913 |
| zzfantasiezz99 (made up) | 2544 | 2544 |

Sample: `https://vsonic.click/e/5b54t4tzp9c2` — resolves through the existing
`const _0x1` branch and plays: master playlist, child playlist, first segment starts
with 0x47 with the usual 188 byte spacing.

The domain answers on its own (HTTP 200, no redirect, no mirror jump in the page).

Pattern change is `vidsonic` to `v(?:id)?sonic` plus `click` in the TLD group. Existing
domains keep matching, and `vsonicx.click`, `sonic.click`, `vsonic.com` stay unmatched.

**What this does not fix.** Most ids on this platform currently do not resolve at all,
and that is unrelated to the new domain — it happens identically on vidsonic.net. Four
of the five ids above decode to a relative path `/uploads/<id>.mp4` instead of an
absolute url, which `resolve()` then discards. Resolving that path against the host
gives a 404 on vidsonic.net, vsonic.click and the CDN host alike, so I have no fix to
offer for it. Only ids that decode to an absolute link (like the sample above) play.
I mention it so the sample choice does not look arbitrary.